### PR TITLE
Pipe WebRTC recorder

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,7 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  // Use SSL for development server by default
+  "ssl": true
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(environment) {
     rootURL: '/',
     locationType: 'auto',
     pipeLoc: process.env.PIPE_ACCOUNT_HASH,
+    pipeEnv: process.env.PIPE_ENVIRONMENT,
     sentry: {
         dsn: process.env.SENTRY_DSN || '',
         cdn: 'https://cdn.ravenjs.com/3.5.1/ember/raven.min.js',

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
     environment: environment,
     rootURL: '/',
     locationType: 'auto',
+    pipeLoc: process.env.PIPE_ACCOUNT_HASH,
     sentry: {
         dsn: process.env.SENTRY_DSN || '',
         cdn: 'https://cdn.ravenjs.com/3.5.1/ember/raven.min.js',


### PR DESCRIPTION
Minor changes to load additional environment variables needed by Pipe recorder; also force use of SSL locally so that it's possible to use the webRTC recorder in local testing.