### PR TITLE
Save data during preview

### DIFF
--- a/app/controllers/participate.js
+++ b/app/controllers/participate.js
@@ -3,7 +3,6 @@ import Ember from 'ember';
 // Adapted from Lookit's participate controller https://github.com/CenterForOpenScience/lookit/blob/develop/app/controllers/participate.js
 export default Ember.Controller.extend({
     isDirty: function() {
-        // TODO: check the response model to see if it contains unsaved data
         var response = this.get('response');
         return response.get('hasDirtyAttributes');
     },

--- a/app/controllers/preview-without-saving.js
+++ b/app/controllers/preview-without-saving.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import Participate from './participate';
+
+// Adapted from Experimenter's participate controller https://github.com/CenterForOpenScience/lookit/blob/develop/app/controllers/participate.js
+export default Participate.extend({
+    previewData: null,
+    showData: false,
+    showPreviewData(session) {
+        return new Ember.RSVP.Promise((resolve) => {
+            this.set('previewData', JSON.stringify(session.toJSON(), null, 4));
+            this.set('showData', true);
+            this.set('_resolve', resolve);
+        });
+    },
+    _resolve: null,
+    actions: {
+        toggleData() {
+            this.toggleProperty('showData');
+            this.get('_resolve')();
+        },
+        saveResponse(payload, callback) {
+            var response = this.get('response');
+            response.setProperties(payload);
+            response.save().then(callback);
+            this.set('response', response);
+        }
+    }
+});

--- a/app/controllers/preview.js
+++ b/app/controllers/preview.js
@@ -1,34 +1,5 @@
-import Ember from 'ember';
+import Participate from './participate';
 
-// Adapted from Experimenter's preview controller https://github.com/CenterForOpenScience/experimenter/blob/develop/app/controllers/experiments/info/preview.js
-export default Ember.Controller.extend({
-    breadCrumb: 'Preview',
-    experiment: null,
-    session: null,
-    isDirty: function() {
-        return this.get('model.hasDirtyAttributes');
-    },
-
-    _resolve: null,
-    previewData: null,
-    showData: false,
-    showPreviewData(session) {
-        return new Ember.RSVP.Promise((resolve) => {
-            this.set('previewData', JSON.stringify(session.toJSON(), null, 4));
-            this.set('showData', true);
-            this.set('_resolve', resolve);
-        });
-    },
-    actions: {
-        toggleData() {
-            this.toggleProperty('showData');
-            this.get('_resolve')();
-        },
-        saveResponse(payload, callback) {
-            var response = this.get('response');
-            response.setProperties(payload);
-            response.save().then(callback);
-            this.set('response', response);
-        }
-    }
-});
+// Just use the participation controller directly; placeholder in case we later want to
+// have slightly different behavior for the preview
+export default Participate;

--- a/app/mixins/frame-player-route.js
+++ b/app/mixins/frame-player-route.js
@@ -10,13 +10,13 @@ export default Ember.Mixin.create({
         return this.get('store').findRecord('study', params.study_id);
     },
     _getChild(params) {
+        // Note: could handle case where child_id parameter is missing or invalid here and
+        // generate an example child record.
         return this.get('store').findRecord('child', params.child_id);
     },
     _createStudyResponse() {
         let response = this.store.createRecord('response', {
             completed: false,
-            feedback: '',
-            hasReadFeedback: '',
             expData: {},
             sequence: []
         });

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -3,12 +3,13 @@ import DS from 'ember-data';
 export default DS.Model.extend({
     conditions: DS.attr(),
     globalEventTimings: DS.attr({ defaultValue: () => [] }),
-    expData: DS.attr(),
-    sequence: DS.attr(),
-    completed: DS.attr('boolean'),
+    expData: DS.attr({ defaultValue: () => {} }),
+    sequence: DS.attr({ defaultValue: () => [] }),
+    completed: DS.attr('boolean', {defaultValue: false}),
     completedConsentFrame: DS.attr('boolean', {defaultValue: false}),
     child: DS.belongsTo('child'),
     study: DS.belongsTo('study'),
     demographicSnapshot: DS.belongsTo('demographic'),
-    createdOn: DS.attr('date')
+    createdOn: DS.attr('date'),
+    isPreview: DS.attr('boolean', {defaultValue: false})
 });

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-    this.route('preview', {path: '/exp/studies/:study_id/preview'});
+    this.route('preview', {path: '/exp/studies/:study_id/:child_id/preview'});
     this.route('participate', {path: '/studies/:study_id/:child_id'});
     this.route('page-not-found', { path: '/*wildcard' });
     this.route('page-not-found');

--- a/app/routes/preview-without-child-or-saving.js
+++ b/app/routes/preview-without-child-or-saving.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import WarnOnExitRouteMixin from '../mixins/warn-on-exit-route';
+import FramePlayerRoute from '../mixins/frame-player-route';
+
+// Adapted from Experimenter preview route https://github.com/CenterForOpenScience/experimenter/blob/develop/app/routes/experiments/info/preview.js
+export default Ember.Route.extend(WarnOnExitRouteMixin, FramePlayerRoute, {
+    _createStudyResponse() {
+        const response = this._super();
+        response.setProperties({
+            id: 'PREVIEW_DATA_DISREGARD'
+        });
+        return response.reopen({
+            save() {
+                if (this.get('completed')) {
+                    var controller = Ember.getOwner(this).lookup('controller:preview');
+                    controller.showPreviewData(this).then(() => {
+                        // Override the WarnOnExitMixin's behavior
+                        controller.set('forceExit', true);
+                        window.location.href = '/exp/studies/';
+                    });
+                    return Ember.RSVP.reject();
+                } else {
+                    return Ember.RSVP.resolve(this);
+                }
+            }});
+    },
+    _getChild() {
+        let child = this.store.createRecord('child', {
+            id: 'TEST_CHILD_DISREGARD'
+        });
+        return child;
+    }
+});

--- a/app/routes/preview.js
+++ b/app/routes/preview.js
@@ -1,33 +1,12 @@
-import Ember from 'ember';
-import WarnOnExitRouteMixin from '../mixins/warn-on-exit-route';
-import FramePlayerRoute from '../mixins/frame-player-route';
+import Participate from './participate';
 
-// Adapted from Experimenter preview route https://github.com/CenterForOpenScience/experimenter/blob/develop/app/routes/experiments/info/preview.js
-export default Ember.Route.extend(WarnOnExitRouteMixin, FramePlayerRoute, {
+// Adapted from Lookit participate route https://github.com/CenterForOpenScience/lookit/blob/develop/app/routes/participate.js
+export default Participate.extend({
     _createStudyResponse() {
         const response = this._super();
         response.setProperties({
-            id: 'PREVIEW_DATA_DISREGARD'
+            isPreview: true
         });
-        return response.reopen({
-            save() {
-                if (this.get('completed')) {
-                    var controller = Ember.getOwner(this).lookup('controller:preview');
-                    controller.showPreviewData(this).then(() => {
-                        // Override the WarnOnExitMixin's behavior
-                        controller.set('forceExit', true);
-                        window.location.href = '/exp/studies/';
-                    });
-                    return Ember.RSVP.reject();
-                } else {
-                    return Ember.RSVP.resolve(this);
-                }
-            }});
-    },
-    _getChild() {
-        let child = this.store.createRecord('child', {
-            id: 'TEST_CHILD_DISREGARD'
-        });
-        return child;
+        return response;
     }
 });

--- a/app/templates/preview-without-saving.hbs
+++ b/app/templates/preview-without-saving.hbs
@@ -17,3 +17,16 @@
           }}
     {{/if}}
 </div>
+
+{{#bs-modal open=showData title="Data collected during this preview session" closeAction=(action 'toggleData') as |modal|}}
+    {{#modal.body}}
+        <p>
+            <strong> Note: </strong>
+            This dialog will not appear to participants when they complete a study. Instead, the "Finish" button will redirect them to the exit URL you specify.
+        </p>
+        <hr>
+        <pre class="preview-data">
+            {{previewData}}
+        </pre>
+    {{/modal.body}}
+{{/bs-modal}}


### PR DESCRIPTION
Accompanies https://github.com/lookit/lookit-api/pull/450 - upon deploying those changes, will need to re-build all current studies with updated frameplayer. Can use https://staging-lookit.cos.io/exp/studies/99/edit/ for immediate testing of preview view on staging when deployed.