### PR TITLE
Bugfix/161 whitelist characters for frame ids

### DIFF
--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -190,7 +190,7 @@ export default Ember.Mixin.create({
         return [
             'videoStream',
             this.get('experiment.id'),
-            this.get('id'),
+            this.get('id'), // parser enforces that id is composed of a-z, A-Z, -, ., [space]
             this.get('session.id'),
             +Date.now(), // Timestamp in ms
             Math.floor(Math.random() * 1000)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "font-awesome": "~4.7.0",
     "handlebars": "^4.3.0",
-    "lodash": "~4.17.13",
+    "lodash": "~4.17.19",
     "node-sass": "^4.14.1"
   },
   "devDependencies": {

--- a/tests/unit/utils/parse-experiment-test.js
+++ b/tests/unit/utils/parse-experiment-test.js
@@ -23,27 +23,105 @@ var sampleBaseExperiment = {
     pastSessions: []
 };
 
-test('parser two single frames stay single frames', function(assert) {
-    var experiment = $.extend(true, {}, sampleBaseExperiment);
+
+test('parser parses two single frames and they stay single frames', function(assert) {
+    let experiment = $.extend(true, {}, sampleBaseExperiment);
     experiment.structure.sequence = ['aVideo', 'aSound'];
 
-    var parser = new ExperimentParser(experiment);
-    var result = parser.parse()[0];
+    const parser = new ExperimentParser(experiment);
+    const result = parser.parse()[0];
 
-    var expIds = result.map((item) => item.id);
+    const expIds = result.map((item) => item.id);
     assert.deepEqual(expIds, ['0-aVideo', '1-aSound']);
 });
 
+
 test('parser parses a single frame and randomizer', function(assert) {
-    var experiment = $.extend(true, {}, sampleBaseExperiment);
+    let experiment = $.extend(true, {}, sampleBaseExperiment);
     experiment.structure.sequence = ['aVideo', 'notMuchOfAChoice'];
 
-    var parser = new ExperimentParser(experiment);
-    var result = parser.parse()[0];
+    const parser = new ExperimentParser(experiment);
+    const result = parser.parse()[0];
 
-    var expIds = result.map((item) => item.id);
+    const expIds = result.map((item) => item.id);
     assert.deepEqual(expIds, ['0-aVideo', '1-notMuchOfAChoice']);
 });
+
+
+test('parser errors on frame id with _', function(assert) {
+    let experiment = {
+        structure: {
+            frames: {
+                video_frame: {
+                    kind: 'exp-video'
+                }
+            },
+            sequence: ['video_frame']
+        },
+        pastSessions: []
+    };
+
+    let parser = new ExperimentParser(experiment);
+
+    assert.throws(parser.parse, 'Underscore allowed in frame ID; should only allow alphanumeric, -, ., space');
+});
+
+test('parser errors on frame id with /', function(assert) {
+    let experiment = {
+        structure: {
+            frames: {
+                'video/frame': {
+                    kind: 'exp-video'
+                }
+            },
+            sequence: ['video/frame']
+        },
+        pastSessions: []
+    };
+
+    let parser = new ExperimentParser(experiment);
+
+    assert.throws(parser.parse, 'Slash allowed in frame ID; should only allow alphanumeric, -, ., space');
+});
+
+test('parser errors on frame id with special character', function(assert) {
+    let experiment = {
+        structure: {
+            frames: {
+                'video@frame': {
+                    kind: 'exp-video'
+                }
+            },
+            sequence: ['video@frame']
+        },
+        pastSessions: []
+    };
+
+    let parser = new ExperimentParser(experiment);
+
+    assert.throws(parser.parse, '@ allowed in frame ID; should only allow alphanumeric, -, ., space');
+});
+
+test('parser allows frame id with space, dash, ., numbers', function(assert) {
+    let experiment = {
+        structure: {
+            frames: {
+                'video-frame.3 special': {
+                    kind: 'exp-video'
+                }
+            },
+            sequence: ['video-frame.3 special']
+        },
+        pastSessions: []
+    };
+
+    const parser = new ExperimentParser(experiment);
+    const result = parser.parse()[0];
+
+    const expIds = result.map((item) => item.id);
+    assert.deepEqual(expIds, ['0-video-frame.3 special']);
+});
+
 
 test('parser applies parameters to single frame as expected', function(assert) {
 
@@ -70,13 +148,12 @@ test('parser applies parameters to single frame as expected', function(assert) {
         pastSessions: []
     };
 
-
-
     var experiment = $.extend(true, {}, simpleParameterExperiment);
     var parser = new ExperimentParser(experiment);
     var result = parser.parse()[0];
     assert.deepEqual(result[0].kind, 'exp-lookit-text', 'FRAME_TYPE parameter should be substituted in for kind');
 });
+
 
 test('parser creates frame group as expected', function(assert) {
 
@@ -133,6 +210,7 @@ test('parser creates frame group as expected', function(assert) {
                             ]);
 
 });
+
 
 test('parser applies parameters to frame group as expected', function(assert) {
 
@@ -331,7 +409,6 @@ test('parser propagates properties through randomizer as expected', function(ass
                             ]);
 
 });
-
 
 
 test('parser applies nested randomization using parameters', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,15 +8150,10 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.5.1, lodash@~4.17.10, lodash@~4.17.13:
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
-  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
-
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.5.1, lodash@~4.17.10, lodash@~4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Require that frame IDs avoid characters that would cause trouble for generating and parsing video filenames, per #161 