### PR TITLE
prefix payloads for consent videos with 'consent-' to enable detectio…

### DIFF
--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -255,7 +255,7 @@ export default Ember.Mixin.create({
 
     _generateVideoId() {
         return [
-            'videoStream',
+            this.get('frameType') === 'CONSENT' ? 'consent-videoStream' : 'videoStream',
             this.get('experiment.id'),
             this.get('id'), // parser enforces that id is composed of a-z, A-Z, -, ., [space]
             this.get('session.id'),


### PR DESCRIPTION
…n of consent video footage without needing data in db for the frame yet. Don't use before deploying lookit-api-side changes to address https://github.com/lookit/lookit-api/issues/598