### PR TITLE
switch lookawayTone to be relative to standard user-provided baseDir,…

### DIFF
--- a/app/components/exp-lookit-images-audio-infant-control/doc.rst
+++ b/app/components/exp-lookit-images-audio-infant-control/doc.rst
@@ -11,7 +11,7 @@ Infant-controlled version of the :ref:`exp-lookit-images-audio` frame. This work
 
 - end the trial by pressing the ``endTrialKey`` key
 - hold down the ``lookawayKey`` (or the mouse button) to indicate that the child is not looking; the trial will automatically end
-  after the lookaway criterion is met. If the 'lookawayTone' is not 'none' a noise is played while the child is looking
+  after the lookaway criterion is met. If a 'lookawayTone' is provided, a noise is played while the child is looking
   away to help the parent know the looking coding is working.
 
 You can disable either of these behaviors by setting the corresponding key to ``''``.
@@ -67,7 +67,10 @@ than 2 s total, as coded by the parent holding down the P key, it will proceed.
                 "position": "fill"
             }
         ],
+
         "baseDir": "https://www.mit.edu/~kimscott/placeholderstimuli/",
+        "audioTypes": ["ogg", "mp3"],
+
         "autoProceed": true,
         "doRecording": true,
         "durationSeconds": 30,

--- a/app/components/exp-lookit-video-infant-control/doc.rst
+++ b/app/components/exp-lookit-video-infant-control/doc.rst
@@ -9,7 +9,7 @@ Infant-controlled version of the :ref:`exp-lookit-video` frame. This works the s
 
 - end the trial by pressing the ``endTrialKey`` key
 - hold down the ``lookawayKey`` (or the mouse button) to indicate that the child is not looking; the trial will automatically end
-  after the lookaway criterion is met. If the 'lookawayTone' is not 'none' a noise is played while the child is looking
+  after the lookaway criterion is met. If a 'lookawayTone' is provided, a noise is played while the child is looking
   away to help the parent know the looking coding is working.
 
 You can disable either of these behaviors by setting the corresponding key to ``''``.

--- a/app/mixins/infant-controlled-timing.rst
+++ b/app/mixins/infant-controlled-timing.rst
@@ -61,9 +61,9 @@ endTrialKey [String | ``'q'``]
      for this trial. You can look up the names of keys at https://keycode.info. Default is 'q'.
 
 lookawayTone [String | ``'noise'``]
-     Type of audio to play during parent-coded lookaways - 'tone' (A 220), 'noise' (pink noise), or 'none'. These
-     tones are available at https://www.mit.edu/~kimscott/placeholderstimuli/ if you want to use them in
-     instructions.
+    Audio file to play during parent-coded lookaways play during parent-coded lookaways, e.g. tone or noise. This can
+    be either an array of ``{src: 'url', type: 'MIMEtype'}`` objects or a single string relative to ``baseDir/<EXT>``.
+    Sample tones are available at https://www.mit.edu/~kimscott/placeholderstimuli/.
 
 lookawayToneVolume [Number | ``0.25``]
      Volume of lookaway tone, as fraction of full volume (1 = full volume, 0 = silent)


### PR DESCRIPTION
… rather than hard-coded placeholderstimuli directory.

REQUIRES CHANGES:
If using lookawayTone 'none', change to ''.
If using lookawayTone 'noise' or 'tone', either copy those files from https://www.mit.edu/~kimscott/placeholderstimuli/ to your own hosting location (`baseDir`) OR set lookawayTone to [{"src": "https://www.mit.edu/~kimscott/placeholderstimuli/mp3/noise.mp3", "type": "audio/mp3"}] (similarly for 'tone').

Addresses #215