### PR TITLE
Add child hash and response to exit url

### DIFF
--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -3,6 +3,7 @@ import layout from './template';
 
 import FullScreen from '../../mixins/full-screen';
 import ExperimentParser from '../../utils/parse-experiment';
+import { addSearchParams } from '../../utils/add-search-params';
 
 let {
     $
@@ -192,7 +193,11 @@ export default Ember.Component.extend(FullScreen, {
     },
 
     _exit() {
-        this.get('session').save().then(() => window.location = this.get('experiment.exitURL') || '/');
+        const exitUrl = this.get('experiment.exitURL');
+        const hashChildId = this.get('session.hash_child_id');
+        const responseId =  this.get('session.id');
+
+        this.get('session').save().then(() => window.location = addSearchParams(exitUrl, responseId, hashChildId) );
     },
 
     actions: {

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -11,5 +11,6 @@ export default DS.Model.extend({
     study: DS.belongsTo('study'),
     demographicSnapshot: DS.belongsTo('demographic'),
     createdOn: DS.attr('date'),
-    isPreview: DS.attr('boolean', {defaultValue: false})
+    isPreview: DS.attr('boolean', {defaultValue: false}),
+    hash_child_id: DS.attr('string')
 });

--- a/app/utils/add-search-params.js
+++ b/app/utils/add-search-params.js
@@ -1,0 +1,25 @@
+const addSearchParams = function(exitUrl, responseId, hashChildId){
+    try {
+        // Parse URL and search params
+        const url = new URL(exitUrl);
+        const params = new URLSearchParams(url.search);
+
+        // Set child and response values
+        // params.set('child', this.get('session.hash_child_id'));
+        // params.set('response', this.get('session.id'))
+        params.set('child', hashChildId);
+        params.set('response', responseId);
+
+        // Set these changes to the URL 
+        url.search = params;
+
+        // Return updated URL
+        return url.toString();
+
+    } catch (TypeError) {
+        // If the provided URL can't be parsed, return root.
+        return '/'
+    }
+};
+
+export { addSearchParams };

--- a/tests/unit/utils/add-search-params-test.js
+++ b/tests/unit/utils/add-search-params-test.js
@@ -1,0 +1,12 @@
+import { module, test} from 'qunit';
+import { addSearchParams } from '../../../utils/add-search-params';
+
+module('Unit | Utility | add search params');
+
+test('Test add search params function', function(assert) {
+    assert.expect(3);
+    assert.equal(addSearchParams('https://lookit.mit.edu', 'repsonse-id', 'hash-child-id'), 'https://lookit.mit.edu/?child=hash-child-id&response=repsonse-id');
+    assert.equal(addSearchParams('not-a-url', 'repsonse-id', 'hash-child-id'), '/');
+    assert.equal(addSearchParams(undefined, 'repsonse-id', 'hash-child-id'), '/');
+});
+


### PR DESCRIPTION
Add two values to the search parameters of the exit URL.  This requires retrieving the child hash id from response (also known as session within Ember Frame Player).  Additionally, this code should protect the existing exit URL.  