### PR TITLE
Fix documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is a small Ember application that allows both researchers to preview an exp
 participate in an experiment. This is meant to be used in conjunction with the [Lookit API Django project](https://github.com/lookit/lookit-api), which contains the Experimenter and Lookit applications.
 The Django applications will proxy to these Ember routes for previewing/participating in an experiment.
 
-For installation instructions, please see the [Lookit documentation](https://lookit.readthedocs.io/en/develop/ember-app-installation.html). 
+For installation instructions, please see the [Lookit documentation](https://lookit.readthedocs.io/projects/frameplayer/en/latest/). 


### PR DESCRIPTION
Fix the link for EFBs docs in Github's readme.  It was point to a page that resolved to a 404.  