### PR TITLE
Move node version to 12

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 dist: trusty
 language: node_js
 node_js:
-  - 10
+  - 12
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/lookit/ember-lookit-frameplayer.git"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
As AWS SDK does not support node 10, we're going to start using node version 12.  