### PR TITLE
Fix/309 ajv compile frame schema error

### DIFF
--- a/app/components/exp-frame-base/component.js
+++ b/app/components/exp-frame-base/component.js
@@ -488,7 +488,7 @@ let ExpFrameBase = Ember.Component.extend(FullScreen, SessionRecord, {
             }
         }
         catch (error) {
-            console.error(`Failed to compile frameSchemaProperties to use for validating researcher usage of frame type '${this.get('kind')}.`);
+            console.error(`Failed to compile frameSchemaProperties to use for validating researcher usage of frame type '${this.get('kind')}'. Compile error message='${error.message}`);
         }
 
         // Set the language (do this after generating properties to allow use of a generated language property)

--- a/app/components/exp-lookit-change-detection/component.js
+++ b/app/components/exp-lookit-change-detection/component.js
@@ -298,14 +298,14 @@ export default ExpFrameBaseComponent.extend(VideoRecord, PauseUnpause, ExpandAss
                 * @attribute leftSequence
                 */
                 leftSequence: {
-                    type: 'Object'
+                    type: 'object'
                 },
                 /**
                 * Sequence of images shown on the right
                 * @attribute rightSequence
                 */
                 rightSequence: {
-                    type: 'Object'
+                    type: 'object'
                 },
                 videoId: {
                     type: 'string'

--- a/app/components/exp-lookit-images-audio/component.js
+++ b/app/components/exp-lookit-images-audio/component.js
@@ -253,7 +253,7 @@ export default ExpFrameBaseComponent.extend(VideoRecord, PauseUnpause, ExpandAss
                 * @attribute {Boolean} correctImageSelected
                 */
                 correctImageSelected: {
-                    type: 'Boolean'
+                    type: 'boolean'
                 },
                 /**
                 * Source URL of audio played, if any. If multiple sources provided (e.g.

--- a/app/components/exp-lookit-instruction-video/component.js
+++ b/app/components/exp-lookit-instruction-video/component.js
@@ -127,7 +127,7 @@ export default ExpFrameBaseComponent.extend(ExpandAssets, {
         },
 
         requireWatchOrRead: {
-            type: 'Boolean',
+            type: 'boolean',
             description: 'Whether to require that the participant watches the video (or reads the whole transcript) to move on',
             default: true
         },


### PR DESCRIPTION
This PR addresses the [issue #309](https://github.com/lookit/ember-lookit-frameplayer/issues/309) by

- adding the ajv schema compilation error message to the console 
- removing the capitalization errors on type properties

#### Expected behavior

- [x] The exp-lookit-instructions-video frame should not produce this console error.
- [x] If a frame's schema has not been specified correctly, the console error should provide more detail to make it easier to identify the relevant parameter(s).

#### Additional information

Depending on your preferences, it would also be possible to separate the `console.log` into two separate messages e.g.
```javascript
catch (error) {
    console.group('ajv compile error');
    console.error(`Failed to compile frameSchemaProperties to use for validating researcher usage of frame type '${this.get('kind')}'.`);
    console.error(`Compile error message='${error.message}'`);
    console.groupEnd();
}
```
