### PR TITLE
Force node version to be 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/lookit/ember-lookit-frameplayer.git"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12 <13"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Node version changing between projects is annoying.  Hopefully, this change to the package file will help rein in some of this frustration.  When you attempt to use yarn, it'll produce an error asking you to change the version of node.  

When node version is wrong:
```
(denv) Projects/ember-lookit-frameplayer - [develop●] » node -v
v18.18.2
(denv) Projects/ember-lookit-frameplayer - [develop●] » yarn docs
yarn run v1.22.19
warning ../package.json: No license field
error ember-lookit-frameplayer@3.2.0: The engine "node" is incompatible with this module. Expected version ">=12 <13". Got "18.18.2"
error Commands cannot run with an incompatible environment.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Using correct version of node:
```
(denv) Projects/ember-lookit-frameplayer - [tie-down-node-version●] » node -v
v12.22.12
(denv) Projects/ember-lookit-frameplayer - [tie-down-node-version●] » yarn docs
yarn run v1.22.19
warning ../package.json: No license field
$ make html
Running Sphinx v7.1.2
loading pickled environment... done
loading intersphinx inventory from https://lookit.readthedocs.io/en/latest/objects.inv...
... Truncated ...
build succeeded, 1 warning.

The HTML pages are in _build/html.
✨  Done in 0.75s.
```