### PR TITLE
Documentation change: add protocol generator example

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/lookit/ember-lookit-frameplayer.git"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12 <13"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This PR moves the protocol generator documentation change from develop into master.

The documentation change is a new protocol generator example showing how to implement a custom prior participation check for the study and child at the start of a new study session. 

The documentation change adds a new section label to the EFP docs that is referenced by the Lookit documentation (lookit-docs repo), and the Lookit documentation grabs the section labels from the EFP master branch. So this change needs to be merged into master order for the Lookit docs -> EFP docs link to work.