### PR TITLE
Responses with survey-consent should be marked as having consent

### DIFF
--- a/app/components/exp-lookit-survey-consent/component.js
+++ b/app/components/exp-lookit-survey-consent/component.js
@@ -79,6 +79,7 @@ export default ExpFrameBaseComponent.extend({
         finish() {
             let formValid = this.validate();
             if (formValid) {
+                this.session.set('completedConsentFrame', true);
                 this.send('next');
             } else {
                 $('div.exp-lookit-survey-form').scrollTop(0);


### PR DESCRIPTION
This fixes a problem the data not being available to researchers for studies using the `survey-consent` frame. The problem is happening because responses with `survey-consent` are not marked has having a consent frame (`completed_consent_frame` is always `false`), which means that the response session does not appear in the 'consent ruling' area and therefore is never available via the data download pages.

This PR fixes part of issue https://github.com/lookit/lookit-api/issues/1317 in that it makes responses with `survey-consent` available to the researcher via the consent ruling area. 

However it does not close the issue because we still need to flag these responses has having consent via survey (so that the researcher can be sure to check the consent response when accessing the data). 