### PR TITLE
add survey-consent flag to response data

### DIFF
--- a/app/components/exp-lookit-survey-consent/component.js
+++ b/app/components/exp-lookit-survey-consent/component.js
@@ -79,6 +79,8 @@ export default ExpFrameBaseComponent.extend({
         finish() {
             let formValid = this.validate();
             if (formValid) {
+                this.session.set('completedConsentFrame', true);
+                this.session.set('surveyConsent', true);
                 this.send('next');
             } else {
                 $('div.exp-lookit-survey-form').scrollTop(0);

--- a/app/models/response.js
+++ b/app/models/response.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
     sequence: DS.attr({ defaultValue: () => [] }),
     completed: DS.attr('boolean', {defaultValue: false}),
     completedConsentFrame: DS.attr('boolean', {defaultValue: false}),
+    surveyConsent: DS.attr('boolean', {defaultValue: false}),
     child: DS.belongsTo('child'),
     study: DS.belongsTo('study'),
     demographicSnapshot: DS.belongsTo('demographic'),


### PR DESCRIPTION
This PR adds a new `surveyConsent` property to the response data, which flags the response as containing a `survey-consent` frame. This property is necessary for flagging responses on the consent ruling page as containing `survey-consent` data. We are flagging responses that contain survey consent data because these responses must be verified by the researcher after the consent is accepted.

This PR also contains the changes from the PR that fixes the problem with `survey-consent` not setting `completedConsentFrame` to `true` (#352) because it is a branch off of that branch. (They are in separate PRs in case we wanted to put in an immediate fix for the latter issue).

This PR relates to this issue: https://github.com/lookit/lookit-api/issues/1317.