### PR TITLE
Check video container/codec support and set in RecordRTC config (#365)

### DIFF
--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -421,9 +421,9 @@ export default Ember.Mixin.create({
         vid.srcObject = null;
         vid.muted = false;
         vid.volume = 1;
-        this.get('recorder').get('recorder').getDataURL()
-            .then((dataURI) => {
-                vid.src = dataURI;
+        this.get('recorder').get('recorder').getBlob()
+            .then((blob) => {
+                vid.src = URL.createObjectURL(blob);
                 vid.controls = true;
             })
             .catch((err) => {

--- a/app/services/s3.js
+++ b/app/services/s3.js
@@ -31,7 +31,7 @@ class S3 {
         const createResponse = await this.s3.createMultipartUpload({
             Bucket: this.env.bucket,
             Key: this.key,
-            ContentType: "video/mp4",
+            ContentType: "video/webm",
         }).promise();
         this.uploadId = createResponse.UploadId;
         this.logRecordingEvent(`Connection established.`);


### PR DESCRIPTION
This fixes a critical problem with the initial RecordRTC release that caused problems with (1) replaying users' own video recordings and (2) viewing certain video recordings across different browsers. The problem was caused by specifying the `webm` container type without also specifying the codec. We have fixed this by checking the browser's support for specific web/codec combinations and setting this accordingly when initiating the recording.