### PR TITLE
update available languages in docs, edit lang parameter description

### DIFF
--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -17,14 +17,20 @@ test in isn't available, you can add it!
 .. _translation:
 
 language [String]
-    Language to present this frame in. Standard text, like hard-coded button labels, will be translated if a translation
-    file is available for this language. Default values that you can already customize (e.g, most "Next" button labels)
-    will **not** be translated. Text you supply will also not be translated.
+    Language to present this frame in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The frame's standard "hard-coded" text will be translated if a translation file is available for this language. The translations include any text that normally can't be customized with other frame parameters, such as certain button labels (e.g. "Pause", "Resume", "Reload webcam"), default parts of the consent frames, the exti frame survey, and other messages that the participant might see. Default values that you can already customize using frame parameters (e.g, most "Next" button labels) will **not** be translated. Text you supply will also not be translated.
 
     The value of the "language" field will persist across frames once set, so you can set it once at the start of your
     study to set the language for all frames.
 
-    Current options are 'en-US' (English, US), 'nl' (Dutch), and 'it' (Italian).
+    Current options are:
+    - 'en-us': English, US
+    - 'eu': Basque
+    - 'hu': Hungarian
+    - 'it': Italian
+    - 'ja': Japonese
+    - 'nl': Dutch
+    - 'pt': Portuguese
+    - 'pt-br': Portuguese, Brazil
 
     To add another language option, please contact Lookit
     staff. You will need to make a copy of the `English translation file <https://github.com/lookit/ember-lookit-frameplayer/blob/develop/translations/en-us.yaml>`__ and translate the text after the colon

--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -17,12 +17,21 @@ test in isn't available, you can add it!
 .. _translation:
 
 language [String]
-    Language to present this frame in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The frame's standard "hard-coded" text will be translated if a translation file is available for this language. The translations include any text that normally can't be customized with other frame parameters, such as certain button labels (e.g. "Pause", "Resume", "Reload webcam"), default parts of the consent frames, the exit frame survey, and other messages that the participant might see. Default values that you can already customize using frame parameters (e.g, most "Next" button labels) will **not** be translated. Text you supply will also not be translated.
+    Language to present the frame(s) in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The default is "en-us". If we have a translation file for the language specified, then the frame's standard "hard-coded" text will be translated to this language. The value of the "language" field will persist across frames once set, so you can set it once at the start of your study to set the language for all frames.
+    
+    Things that are translated:
+    - Button labels that cannot be modified using another frame parameter (e.g. "Pause", "Resume", "Reload webcam")
+    - Default text in the consent frames
+    - The exit frame survey
+    - Any other text/messages that the participant might see *that cannot be customized with other frame parameters*
+    
+    Things that are NOT translated: 
+    - Default values that you can already customize using frame parameters (e.g. most "Next" button labels)
+    - Any other text that you provide in the frame parameters
 
-    The value of the "language" field will persist across frames once set, so you can set it once at the start of your
-    study to set the language for all frames.
+    To see the specific text strings that are translated, along with their values for each language, see the `translations directory <https://github.com/lookit/ember-lookit-frameplayer/tree/master/translations>`__ in the Lookit Github repository.
 
-    Current options are:
+    The current options for the language parameter are:
     - 'en-us': English, US
     - 'eu': Basque
     - 'hu': Hungarian
@@ -32,9 +41,7 @@ language [String]
     - 'pt': Portuguese
     - 'pt-br': Portuguese, Brazil
 
-    To add another language option, please contact Lookit
-    staff. You will need to make a copy of the `English translation file <https://github.com/lookit/ember-lookit-frameplayer/blob/develop/translations/en-us.yaml>`__ and translate the text after the colon
-    on each line, leaving everything else the same. You can see an example `here <https://github.com/lookit/ember-lookit-frameplayer/blob/develop/translations/nl.yaml>`__. There are three special cases:
+    To add another language option, please contact Lookit staff. You will need to make a copy of the `English translation file <https://github.com/lookit/ember-lookit-frameplayer/blob/develop/translations/en-us.yaml>`__ and translate the text after the colon on each line, leaving everything else the same. You can see an example `here <https://github.com/lookit/ember-lookit-frameplayer/blob/develop/translations/nl.yaml>`__. There are three special cases:
 
     * If there's HTML formatting, leave it be (just edit the text). E.g. ``<strong>Private</strong>`` became
       ``<strong>Privé:</strong>`` in Dutch.

--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -20,18 +20,21 @@ language [String]
     Language to present the frame(s) in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The default is "en-us". If we have a translation file for the language specified, then the frame's standard "hard-coded" text will be translated to this language. The value of the "language" field will persist across frames once set, so you can set it once at the start of your study to set the language for all frames.
     
     Things that are translated:
+
     - Button labels that cannot be modified using another frame parameter (e.g. "Pause", "Resume", "Reload webcam")
     - Default text in the consent frames
     - The exit frame survey
     - Any other text/messages that the participant might see *that cannot be customized with other frame parameters*
     
     Things that are NOT translated: 
+
     - Default values that you can already customize using frame parameters (e.g. most "Next" button labels)
     - Any other text that you provide in the frame parameters
 
     To see the specific text strings that are translated, along with their values for each language, see the `translations directory <https://github.com/lookit/ember-lookit-frameplayer/tree/master/translations>`__ in the Lookit Github repository.
 
     The current options for the language parameter are:
+    
     - 'en-us': English, US
     - 'eu': Basque
     - 'hu': Hungarian

--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -17,7 +17,7 @@ test in isn't available, you can add it!
 .. _translation:
 
 language [String]
-    Language to present this frame in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The frame's standard "hard-coded" text will be translated if a translation file is available for this language. The translations include any text that normally can't be customized with other frame parameters, such as certain button labels (e.g. "Pause", "Resume", "Reload webcam"), default parts of the consent frames, the exti frame survey, and other messages that the participant might see. Default values that you can already customize using frame parameters (e.g, most "Next" button labels) will **not** be translated. Text you supply will also not be translated.
+    Language to present this frame in. This is specified using the two-letter language code (and sometimes a subtag indicating the language variant) - see options listed below. The frame's standard "hard-coded" text will be translated if a translation file is available for this language. The translations include any text that normally can't be customized with other frame parameters, such as certain button labels (e.g. "Pause", "Resume", "Reload webcam"), default parts of the consent frames, the exit frame survey, and other messages that the participant might see. Default values that you can already customize using frame parameters (e.g, most "Next" button labels) will **not** be translated. Text you supply will also not be translated.
 
     The value of the "language" field will persist across frames once set, so you can set it once at the start of your
     study to set the language for all frames.

--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -27,7 +27,7 @@ language [String]
     - 'eu': Basque
     - 'hu': Hungarian
     - 'it': Italian
-    - 'ja': Japonese
+    - 'ja': Japanese
     - 'nl': Dutch
     - 'pt': Portuguese
     - 'pt-br': Portuguese, Brazil


### PR DESCRIPTION
This PR adds makes some minor edits to the documentation about the language parameter, and adds the following languages to the list that are available for translation:
- Basque
- Hungarian
- Japanese
- Portuguese
- Portuguese (Brazil)