### PR TITLE
Fix Basque and Hungarian translation errors

### DIFF
--- a/translations/eu.yaml
+++ b/translations/eu.yaml
@@ -105,11 +105,11 @@ consent-template-5:
     procedures-header: Ikerketa egin bitartean
     duration-statement: Ikerketak {duration} inguru eskatzen du.
     participation-header: Parte hartzea ez da derrigorrezkoa
-    participation-content: Zu eta haurra askeak zarete ikerketan parte hartu nahi duzuen erabakitzeko. If you do choose to participate, it's okay to stop at any point during the session. {only_adult, select, true {} other {Please do pause or stop the session if your child becomes fussy or does not want to participate!}}
+    participation-content: Zu eta haurra askeak zarete ikerketan parte hartu nahi duzuen erabakitzeko. Parte hartzea erabakitzen baduzu, ez izan eragozpenik saioa edozein momentutan uzteko. {only_adult, select, true {} other {Haurra haserretzen hasten bada edo ez badu parte hartu nahi, pausatu edo utzi saioa mesedez.}}
     risk-header: Zer arrisku dago?
     benefits-header: Zer onura dago?
     data-collection-header: Datuak biltzea eta webcamaren bidez grabatzea
-    data-collection-1: Saioan, zu {only_adult, select, true {} other {and your child}} ordengailuko webcamaren eta mikrofonoaren bidez grabatuko zaituztegu.
+    data-collection-1: Saioan, zu {only_adult, select, true {} other {eta zure haurra}} ordengailuko webcamaren eta mikrofonoaren bidez grabatuko zaituztegu.
     data-collection-2: Webcamaren grabazioak eta galdetegietan emandako erantzunak Lookit plataformara bidaltzen diran era seguruan. Aurreko grabazioak Lookiten ikus ditzakezu edozein unetan.
     data-collection-3: Datuak modu seguruan gordetzen dira Lookiten serbidoreetan eta ikertzaileen ordenagailuetan, eta hemen deskribatzen den bezala baizik ez dira partekatuko. Hala ere, therebeti dago internet bidez bidaltzen diren datuak lapurtuak izateko edo datuak babesteko segurtasuna gainditua izateko arrisku txiki bat.
     video-privacy-header: Nork ikusi ahalko ditu zure webcamaren grabazioak?

--- a/translations/hu.yaml
+++ b/translations/hu.yaml
@@ -75,7 +75,7 @@ consent-template-2:
     intro-sentence: '{name} által vezetett kutatòk {institution} irányítják ezt a, "{experiment},"-et Lookit-on.'
     purpose-header: Cél
     procedures-header: Eljárás
-    duration-statement: Ez a tanulmány körülbelül {duration} ideig tart.
+    duration-statement: Ez a kísérlet teljesítési ideje körülbelül {duration}.
     participation-header: Részvétel
     participation-content: Ön és gyermeke szabadon dönthet arról, hogy részt kíván -e venni ebben a vizsgálatban. Ha Ön és gyermeke úgy dönt, hogy részt vesz, a foglalkozás során bármikor abbahagyhatja. Kérjük, szüneteltesse vagy állítsa le a foglalkozást, ha gyermeke nagyon nyűgös lesz, vagy nem akar részt venni! Ha ez egy többszöri részvételbõl tudja csak befejezni, akkor az is megfelelõ, ha nem fejezi be az összes munkamenetet.
     payment-header: Fizetés
@@ -103,7 +103,7 @@ consent-template-5:
     intro-sentence: A(z) {institution} intéyményben lévõ és a(z) {name} által vezetett kutatók végzik ezt a tanulmányt, a "{experiment}" -et a Lookit-on.
     purpose-header: Miért végezzük ezt a tanulmányt?
     procedures-header: Mi történik a vizsgálat során?
-    duration-statement: Ez a tanulmány körülbelül {duration} időt vesz majd igénybe.
+    duration-statement: Ez a kísérlet teljesítési ideje körülbelül {duration}.
     participation-header: A részvétel önkéntes
     participation-content: Ön {only_adult, select, true {} other {és gyermeke}} szabadon dönthet arról, hogy részt vesz-e ebben a tanulmányban. Ha úgy dönt, hogy részt vesz, akkor a foglakozás során bármikor abbahagyhatja. {only_adult, select, true {} other {Kérjük, szüneteltesse vagy állítsa le a munkamenetet, ha gyermeke nyűgös lesz, vagy nem akar a továbbiakban részt venni!}}
     risk-header: Mik a kckázatok?


### PR DESCRIPTION
This PR fixes a few translation errors that were found after merging the Basque and Hungarian translations into `develop`.

@NevenaKlo could you have a quick look, please? Thanks!