### PR TITLE
Docs changes: fix broken links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -E
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = ./app
 BUILDDIR      = _build

--- a/app/components/exp-frame-base/conditional_logic.rst
+++ b/app/components/exp-frame-base/conditional_logic.rst
@@ -1,4 +1,4 @@
-.. _Conditional logic:
+.. _conditional_logic:
 
 Conditional logic
 -----------------

--- a/app/components/exp-frame-base/doc.rst
+++ b/app/components/exp-frame-base/doc.rst
@@ -59,7 +59,7 @@ language [String]
 
 There are several parameters that ALL frames accept to allow you to customize the study "flow," which are:
 
-.. _select next frame:
+.. _selectnextframe:
 
 selectNextFrame [String]
     Function to select which frame index to go to when using the 'next' action on this

--- a/app/components/exp-frame-select/doc.rst
+++ b/app/components/exp-frame-select/doc.rst
@@ -11,7 +11,7 @@ list of indices of which ones to actually show.
 
 The frame(s) will be inserted into the sequence of frames for this study on the fly, so that you can use a custom
 :ref:`generateProperties<generateProperties>` function to select which frame(s) to show. (For more information on
-making study behavior conditional on data collected, see :ref:`conditional_logic`.)
+making study behavior conditional on data collected, see :ref:`Conditional Logic<conditional_logic>`.)
 
 This frame serves as a wrapper for the randomizer :ref:`select<select>`,
 which is evaluated during experiment parsing and cannot be modified on the fly.

--- a/app/components/exp-frame-select/doc.rst
+++ b/app/components/exp-frame-select/doc.rst
@@ -20,7 +20,7 @@ Warning: no ``selectNextFrame`` available
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To avoid unpredictable behavior, this frame does not itself use any
-:ref:`selectNextFrame<selectNextFrame>` passed to it. (Frames *within* the ``frameOptions`` list are welcome to make use of
+:ref:`selectNextFrame<selectnextframe>` passed to it. (Frames *within* the ``frameOptions`` list are welcome to make use of
 ``selectNextFrame``, though!)
 
 Finding data from frames created by exp-lookit-select

--- a/app/conf.py
+++ b/app/conf.py
@@ -28,7 +28,7 @@ author = 'MIT'
 # ones.
 extensions = ['sphinx.ext.intersphinx']
 
-intersphinx_mapping = {'docs': ('https://lookit.readthedocs.io/en/latest/', None)}
+intersphinx_mapping = {'docs': ('https://lookit.readthedocs.io/en/develop/', None)}
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/app/randomizers/overview.rst
+++ b/app/randomizers/overview.rst
@@ -30,7 +30,7 @@ For complex counterbalancing designs, this may be simpler to reason about and de
 without having to learn any special Lookit syntax. See :ref:`'Protocol generators'<generators>` for more information.
 
 A protocol generator function can do anything that a randomizer frame can do. But to set up
-:ref:`conditional logic<Conditional logic>` (doing different things depending on what the family does *this session*),
+:ref:`conditional logic<conditional_logic>` (doing different things depending on what the family does *this session*),
 you will still need to use ``generateProperties`` or ``selectNextFrame`` parameters within the protocol you generate.
 
 3. Randomizer frames


### PR DESCRIPTION
This PR fixes a few broken links in the docs:
- Some links between the lookit-api and EFP docs weren't working because the lookit-api docs URL we had for intersphinx mapping no longer works
- Some EFP links were broken because of spaces in the section labels/references

This also adds the -E (--fresh-env) option to the sphinx build command, because our existing build command only re-builds new/changed files but wasn't picking up my file changes (cache busting problem?).