### PR TITLE
`iframe` changes: allow submit forms, allow setting the source via `generateProperties`

### DIFF
--- a/app/components/exp-lookit-iframe/component.js
+++ b/app/components/exp-lookit-iframe/component.js
@@ -36,11 +36,12 @@ export default ExpFrameBaseComponent.extend({
     },
 
     didReceiveAttrs() {
-        const iframeSrc = this.get('frameConfig.iframeSrc');
+        // call super first in case iframeSrc comes from generateProperties
+        this._super(...arguments);
+        const iframeSrc = this.get('iframeSrc');
         const hashChildId = this.get('session.hash_child_id');
         const responseId =  this.get('session.id');
         this.set('frameConfig.iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
-        this._super(...arguments);
     }
 
 });

--- a/app/components/exp-lookit-iframe/component.js
+++ b/app/components/exp-lookit-iframe/component.js
@@ -1,7 +1,6 @@
 import layout from './template';
 import ExpFrameBaseComponent from '../exp-frame-base/component';
 import { addSearchParams } from '../../utils/add-search-params';
-import $ from 'jquery';
 
 
 export default ExpFrameBaseComponent.extend({
@@ -42,16 +41,15 @@ export default ExpFrameBaseComponent.extend({
         const hashChildId = this.get('session.hash_child_id');
         const responseId =  this.get('session.id');
         this.set('frameConfig.iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
+    },
+
+    didInsertElement() {
+        this._super(...arguments);
+        function enableNextbutton(){
+            document.querySelector('#nextbutton').removeAttribute('disabled')
+        }
+        setTimeout(enableNextbutton, 3000);
+        document.querySelector('iframe').onload = enableNextbutton
     }
 
-});
-
-
-function enableNextbutton(){
-    document.querySelector('#nextbutton').removeAttribute('disabled')
-}
-
-$(function() {
-    setTimeout(enableNextbutton, 3000);
-    document.querySelector('iframe').onload = enableNextbutton
 });

--- a/app/components/exp-lookit-iframe/component.js
+++ b/app/components/exp-lookit-iframe/component.js
@@ -40,7 +40,7 @@ export default ExpFrameBaseComponent.extend({
         const iframeSrc = this.get('iframeSrc');
         const hashChildId = this.get('session.hash_child_id');
         const responseId =  this.get('session.id');
-        this.set('frameConfig.iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
+        this.set('iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
     },
 
     didInsertElement() {

--- a/app/components/exp-lookit-iframe/template.hbs
+++ b/app/components/exp-lookit-iframe/template.hbs
@@ -2,9 +2,9 @@
     height={{ iframeHeight }} 
     width={{ iframeWidth }} 
     src={{ iframeSrc }} 
-    sandbox="allow-scripts allow-same-origin" 
+    sandbox="allow-scripts allow-same-origin allow-forms"
     referrerpolicy="no-referrer"
-/>
+></iframe>
 {{#if optionalText }}<p>{{ optionalText }}</p>{{/if}}
 {{#if optionalExternalLink }}
     <p>


### PR DESCRIPTION
This PR fixes some issues related to presenting a Calendly booking form in an iframe: #374. Specifically:

- Calendly requires specific names for the query parameters, but our iframe always calls them 'child' and 'response'. This PR addresses this by allowing researchers to use `generateProperties` to dynamically generate the `iframeSrc` URL with the query parameter names/values that they need. (Note: we are considering other solutions to the query parameter name problem for the iframe URL and other links. This is a quick fix in the meantime, and it fixes the more general problem of the `iframeSrc` parameter not working with `generateProperties`).
- The final form submission button in booking a Calendly appointment was not working in an iframe, though the rest of the booking process does. This was because we did not include the "allow-forms" sandbox attribute for the iframe.

This PR fixes the two issues above by doing the following:

- Adds the 'allow-forms' setting to the iframe element in `exp-lookit-iframe`. This change is needed to be able to schedule a Calendly event from inside an iframe.
- Allows researchers to use the frame's `generateProperties` parameter to generate the iframe source. This allows researchers to dynamically add query parameters/values to the end of the the source URL. (This wasn't possible before because the URL was being modified/set in `didReceiveAttrs` via `addSearchParams` before the base frame generated the parameter value, so the URL was undefined and caused an error.)
- Moves the function to enable the 'next' button into `didInsertElement`. It was previously called in the jquery document ready callback, but for some reason the document ready event callback was not being triggered with Calendly iframe links, which meant that the next button was never enabled. 