### PR TITLE
Reduce max recording time

### DIFF
--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -146,7 +146,7 @@ export default Ember.Mixin.create({
         $('#' + this.get('elementId')).parent().append($sessionRecorderElement);
         var $element = $('#' + recorderElementId);
 
-        const maxRecordingLength = 100000000;
+        const maxRecordingLength = 7200;
         const sessionVideoId = this._generateSessionVideoId();
         this.get('session').set('videoId', sessionVideoId);
         const sessionRecorder = new VideoRecorder({element: $element});

--- a/app/mixins/video-record.rst
+++ b/app/mixins/video-record.rst
@@ -47,8 +47,8 @@ If your frame uses the video-record mixin, you can specify the following in addi
 
 .. glossary::
 
-    maxRecordingLength [Number | ``7200``]
-        Maximum recording length in seconds
+    maxRecordingLength [Number (1-7200) | ``7200``]
+        Maximum recording length in seconds. The default is 7200 seconds, which is also the upper limit. The maximum recording length must be at least 1 second. Recording will automatically stop if this duration is reached.
 
     maxUploadSeconds [Number | ``5``]
         Maximum time allowed for video upload before proceeding to next frame, in seconds. Can be overridden by

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -169,7 +169,7 @@ const VideoRecorder = Ember.Object.extend({
      * @return {Promise} Resolves when widget successfully installed and started
      */
 
-    install(videoFilename = '', maxRecordingTime = 100000000, checkMic = false, s3vars = {}) {
+    install(videoFilename = '', maxRecordingTime = 7200, checkMic = false, s3vars = {}) {
 
         let origDivId = this.get('divId');
 


### PR DESCRIPTION
This PR does the following: 
- Reduces the default maximum recording duration to 7200 seconds
- Adds a hard upper limit for recording durations, so that it cannot be arbitrarily increased by users.
- Checks if the researcher-provided maximum recording duration is above the upper limit or below a minimum value (1 second), and if so, displays a warning in the console and changes the value to the min/max.
