### PR TITLE
iframe improvements; fix recording time limit

### DIFF
--- a/app/components/exp-lookit-iframe/component.js
+++ b/app/components/exp-lookit-iframe/component.js
@@ -1,7 +1,6 @@
 import layout from './template';
 import ExpFrameBaseComponent from '../exp-frame-base/component';
 import { addSearchParams } from '../../utils/add-search-params';
-import $ from 'jquery';
 
 
 export default ExpFrameBaseComponent.extend({
@@ -36,21 +35,21 @@ export default ExpFrameBaseComponent.extend({
     },
 
     didReceiveAttrs() {
-        const iframeSrc = this.get('frameConfig.iframeSrc');
+        // call super first in case iframeSrc comes from generateProperties
+        this._super(...arguments);
+        const iframeSrc = this.get('iframeSrc');
         const hashChildId = this.get('session.hash_child_id');
         const responseId =  this.get('session.id');
-        this.set('frameConfig.iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
+        this.set('iframeSrc', addSearchParams(iframeSrc, responseId, hashChildId));
+    },
+
+    didInsertElement() {
         this._super(...arguments);
+        function enableNextbutton(){
+            document.querySelector('#nextbutton').removeAttribute('disabled')
+        }
+        setTimeout(enableNextbutton, 3000);
+        document.querySelector('iframe').onload = enableNextbutton
     }
 
-});
-
-
-function enableNextbutton(){
-    document.querySelector('#nextbutton').removeAttribute('disabled')
-}
-
-$(function() {
-    setTimeout(enableNextbutton, 3000);
-    document.querySelector('iframe').onload = enableNextbutton
 });

--- a/app/components/exp-lookit-iframe/template.hbs
+++ b/app/components/exp-lookit-iframe/template.hbs
@@ -2,9 +2,9 @@
     height={{ iframeHeight }} 
     width={{ iframeWidth }} 
     src={{ iframeSrc }} 
-    sandbox="allow-scripts allow-same-origin" 
+    sandbox="allow-scripts allow-same-origin allow-forms"
     referrerpolicy="no-referrer"
-/>
+></iframe>
 {{#if optionalText }}<p>{{ optionalText }}</p>{{/if}}
 {{#if optionalExternalLink }}
     <p>


### PR DESCRIPTION
This PR moves the following changes into production:
- Allows the `iframe` frame to submit forms so that it can be used with booking sites (e.g. Calendly) (#376)
- Allows the `iframe` frame's `iframeSrc` parameter to come from `generateProperties`, so that custom query parameter names/values can be dynamically added to the end of the URL (#376)
- Reduces the maximum recording duration default value and sets a hard limit on this value (#377)
- Fixes some broken links in the documentation (#372)