### PR TITLE
Fix blank consent recordings

### DIFF
--- a/app/components/exp-lookit-video-assent/template.hbs
+++ b/app/components/exp-lookit-video-assent/template.hbs
@@ -33,20 +33,26 @@
 
                 <div class="exp-lookit-assent-visual-container">
 
-                    {{#if currentPage.imgSrc}}
-                        <img class="exp-lookit-assent-image" src={{currentPage.imgSrc}} alt={{currentPage.altText}}>
-                    {{/if}}
-
                     <div class="row recorder-container {{unless currentPage.showWebcam "hidden-webcam"}}">
                         <div id="recorder" class="col-xs-12"></div>
                     </div>
 
-                    <video id="assent-video" class="exp-lookit-assent-image {{unless currentPage.video "hidden"}}" controls onended={{action "videoCompleted"}}>
-                        {{#each currentPage.video as |vidsource|}}
-                            <source src={{vidsource.src}} type={{vidsource.type}}>
-                        {{/each}}
-                        Your browser does not support the video tag.
-                    </video>
+                    {{#if recorderInitializing}} ({{t "please wait, setting up" }}...)
+
+                    {{else}}
+
+                        {{#if currentPage.imgSrc}}
+                            <img class="exp-lookit-assent-image" src={{currentPage.imgSrc}} alt={{currentPage.altText}}>
+                        {{/if}}
+
+                        <video id="assent-video" class="exp-lookit-assent-image {{unless currentPage.video "hidden"}}" controls onended={{action "videoCompleted"}}>
+                            {{#each currentPage.video as |vidsource|}}
+                                <source src={{vidsource.src}} type={{vidsource.type}}>
+                            {{/each}}
+                            Your browser does not support the video tag.
+                        </video>
+
+                    {{/if}}
 
                 </div>
 

--- a/app/components/exp-lookit-video-consent/component.js
+++ b/app/components/exp-lookit-video-consent/component.js
@@ -40,8 +40,8 @@ The consent document can be downloaded as PDF document by participant.
 export default ExpFrameBaseComponent.extend(VideoRecord, {
     layout: layout,
     frameType: 'CONSENT',
-    disableRecord: Em.computed('recorder.recording', 'recorder.hasCamAccess', function () {
-        return !this.get('recorder.hasCamAccess') || this.get('recorder.recording');
+    disableRecord: Em.computed('recorder.recording', 'recorder.hasCamAccess', 'recorderReady', function () {
+        return !(this.get('recorder.hasCamAccess') && this.recorderReady && !this.get('recorder.recording'));
     }),
     startedRecording: false,
     hasCheckedVideo: false,
@@ -641,7 +641,7 @@ export default ExpFrameBaseComponent.extend(VideoRecord, {
         this.set('consentFormText', $('#consent-form-text').text());
         $('#recordingIndicator').hide();
         $('#recordingText').text(this._translate('exp-lookit-video-consent.Not-recording-yet'));
-        $('#recordbutton').prop('disabled', false);
+        $('#recordbutton').prop('disabled', true);
         $('#stopbutton').prop('disabled', true);
         $('#playbutton').prop('disabled', true);
     }


### PR DESCRIPTION
Fixes #387

## Summary

This PR fixes the problem with blank consent videos with the following changes:

`video-consent`

1. Disable the 'start recording' button when the video consent page first loads, so that it only becomes enabled when the recorder is ready.
2. Require the 'recorderReady' property to be true before enabling the 'start recording' button. 

`video-assent`

1. If trial recording is used, check if the recorder is ready when the trial loads. If so, show a (translated) 'please wait' message and wait until the recorder is actually ready to record before starting the trial.
2. Whenever the recorder is ready, either show the first consent page (if `recordLastPage` is true), or start recording and then trigger the first consent page after recording has started (if `recordWholeProcedure` is true).

## Testing steps

I've done this testing locally on Firefox and Chrome. I will repeat these tests on staging/production once the code is reviewed.

### `video-consent`

- Create a study that starts with a video consent frame (so that the recorder takes longer to initialize). 
- As soon as the start recording button appears, immediately start clicking it and continue until the recording actually starts. 
- After the recording starts, stop the recording, and then click the replay button. You should see the video replay on the page (not a black screen). You should not be able to continue through the study until you play the recording.

### `video-assent`

**record whole procedure**
- Create a study that starts with a video assent frame (so that the recorder takes longer to initialize), with `recordWholeProcedure: true`.
- When the trial starts, there should be a 'please wait' message and the first consent page should not be visible. Once the recorder is ready, it should start recording, the 'please wait' message should not be visible, and the first consent page should be shown.

**record last page**
- Create a study that starts with a video assent frame (so that the recorder takes longer to initialize), with `recordLastPage: true`.
- When the trial starts, there should be a 'please wait' message and the first consent page should not be visible. Once the recorder is ready, the 'please wait' message should not be visible and the first consent page should be shown. On the last consent page, the recording should start.

**no recording**
- Create a study that starts with a video assent frame with no trial recording.
- The 'please wait' message should never be visible and the first consent page should be shown immediately.

**session recording**
- Create a study that starts with a start recording frame (so that the recorder takes longer to initialize), then a video assent frame with no trial recording, then an end recording frame.
- The recording set-up should be taken care of during the start recording frame, so that the recorder is ready when the video-assent trial begins.
- The 'please wait' message should never be visible and the first consent page should be shown immediately.

### For all tests

- Check that there are no console errors, e.g. related to stopping the trial/session recording, and that the video is saved. There are console logs related to completing the video file upload, so that's probably sufficient.
- To prolong the recording set-up time, remove the video recording permissions for the site that are saved in your browser settings so that you're asked for recording permission when the page loads. The 'start recording' button should remain disabled until you after you give permission for the page to record.
- Repeat these tests in Chrome and Firefox.

## Screenshots

Here's what video-consent looks like before the recorder is ready. (It's a little hard to tell, but the 'start consent recording' button is disabled.) 

The browser permissions request is just there because I intentionally revoked the permissions to stop the recorder from being ready while I got a screenshot - if the permissions were already granted then they will not be requested again!

![Screenshot 2024-05-30 at 12 10 01 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/9168161e-c043-4486-beb6-81cbd252a03b)

Here's what video-assent looks like when trial recording is used and the recorder is not ready. 

The browser permissions request is just there because I intentionally revoked the permissions to stop the recorder from being ready while I got a screenshot - if the permissions were already granted then they will not be requested again!

![Screenshot 2024-05-30 at 12 01 43 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/023e1a15-207d-4c72-90ed-d05c0094fc0a)
