### PR TITLE
Iframe word wrap

### DIFF
--- a/app/components/exp-lookit-iframe/template.hbs
+++ b/app/components/exp-lookit-iframe/template.hbs
@@ -14,7 +14,7 @@
             to open this part of the study in a new tab. Make sure to keep this tab open so you can continue to the rest of the study.
         </p>
     {{/if}}
-    <div class="center-text" id="warningmessage"><p class="warning">{{ warningMessageText }}</p></div>
+    <div class="center-text" id="warningmessage"><p>{{ warningMessageText }}</p></div>
     <div class="row exp-controls">
         <div class="col-md-12">
             <button type="button" id="nextbutton" disabled="" class="btn btn-success pull-right next" > {{exp-format nextButtonText}} </button>

--- a/app/styles/components/exp-lookit-iframe.scss
+++ b/app/styles/components/exp-lookit-iframe.scss
@@ -1,8 +1,7 @@
 .exp-lookit-iframe {
-    .warning {
-        color: red;
-    }
     #warningmessage {
-        visibility: hidden
+        visibility: hidden;
+        overflow-wrap: break-word;
+        color: red;
     }
 }


### PR DESCRIPTION
# Summary

By default, a long string of characters will not wrap without whitespace.  To overcome this issue, I've added an attribute for overflow to the SCSS for that text block.  

<img width="1316" alt="Screenshot 2024-05-29 at 1 32 29 PM" src="https://github.com/lookit/ember-lookit-frameplayer/assets/44074998/151b9c7e-8e66-4318-8a20-421345b1efb3">

<img width="1333" alt="Screenshot 2024-05-29 at 1 36 25 PM" src="https://github.com/lookit/ember-lookit-frameplayer/assets/44074998/ead4aedf-9ca8-475f-a30c-8eaa651a2522">


