### PR TITLE
iframe updates; blank video recording fix

### DIFF
--- a/app/components/exp-lookit-iframe/component.js
+++ b/app/components/exp-lookit-iframe/component.js
@@ -19,11 +19,19 @@ export default ExpFrameBaseComponent.extend({
             type:'string',
             default:'100%'
         },
-        optionalText:{
+        instructionText:{
             type:'string'
         },
         optionalExternalLink:{
             type:'boolean'
+        },
+        nextButtonText: {
+            type: 'string',
+            default: 'Next'
+        },
+        warningMessageText:{
+            type: 'string',
+            default: 'Please confirm that you have finished the task above! When you have finished, click the button to continue.'
         }
     },
 
@@ -33,6 +41,8 @@ export default ExpFrameBaseComponent.extend({
             properties: {}
         }
     },
+
+    confirmedContinue: false,
 
     didReceiveAttrs() {
         // call super first in case iframeSrc comes from generateProperties
@@ -45,6 +55,22 @@ export default ExpFrameBaseComponent.extend({
 
     didInsertElement() {
         this._super(...arguments);
+        // When the next button is first clicked, display the warning/confirmation message,
+        // and then wait 2 sec before allowing another click.
+        // On the subsequent button click, trigger the next frame action.
+        let timer;
+        document.querySelector("#nextbutton")
+            .addEventListener('click', () => {
+                if (!timer) {
+                    document.querySelector("#warningmessage").style.visibility = "visible";
+                    timer = setTimeout(() => {
+                        this.confirmedContinue = true;
+                    }, 2000);
+                } 
+                if (this.confirmedContinue) {
+                    this.next();
+                }
+            });
         function enableNextbutton(){
             document.querySelector('#nextbutton').removeAttribute('disabled')
         }

--- a/app/components/exp-lookit-iframe/doc.rst
+++ b/app/components/exp-lookit-iframe/doc.rst
@@ -16,8 +16,8 @@ Lookit study. For this reason, if your study methods allow it, we suggest moving
 Lookit study. You can automatically direct participants to another website at the end of the Lookit study using the study's 
 '`Exit URL <https://lookit.readthedocs.io/en/develop/researchers-set-study-fields.html#exit-url>`_'.
 
-If you do need to embed an external website in the middle of a Lookit study, this frame includes the optionalText parameter, which 
-allows you to add text underneath the iframe box. You can use this text to help ensure the participant completes everything in the 
+If you do need to embed an external website in the middle of a Lookit study, this frame includes the instructionText parameter, which 
+allows you to add text above the iframe box. You can use this text to help ensure the participant completes everything in the 
 iframe box before clicking the frame's 'Next' button, e.g. "Please make sure that you see the message 'Your response has been 
 submitted' in the box above before clicking the next button below."
 
@@ -32,10 +32,6 @@ video file (link to documentation: https://lookit.readthedocs.io/en/develop/rese
 More generally, remember that the Lookit study has no way of 'knowing' what sorts of interactions the participant has, or has 
 not had, on the external website. For example, there is no way to ensure that the participant has made a response on the 
 external site before they click the 'Next' button to continue on with the Lookit study.
-
-This frame includes the optionalText parameter, which allows you to add text underneath the iframe box. You can use this text 
-to help ensure the participant completes everything in the iframe box before clicking the frame's 'Next' button, e.g. "Please 
-make sure that you see the message 'Your response has been submitted' in the box above before clicking the next button below."
 
 What it looks like
 ~~~~~~~~~~~~~~~~~~
@@ -54,7 +50,9 @@ and data collected that come from the following more general sources:
 Examples
 ----------------
 
-This will present the website "example.com" inside an iframe within the Lookit experiment. The `iframe` frame will automatically add two query parameters to the end of the `iframeSrc` link: "child" (the child ID) and "response" (the response ID). This allows researchers to automatically link responses obtained via the external site embedded in the iframe to Lookit data.
+This will present the website "example.com" inside an iframe within the Lookit experiment. The `iframe` frame will automatically add two 
+query parameters to the end of the `iframeSrc` link: "child" (the child ID) and "response" (the response ID). This allows researchers to 
+automatically link responses obtained via the external site embedded in the iframe to Lookit data.
 
 .. code:: javascript
 
@@ -63,10 +61,15 @@ This will present the website "example.com" inside an iframe within the Lookit e
         "iframeSrc": "https://example.com",
         "iframeHeight": "700px",
         "iframeWidth": "100%",
-        "optionalText": "Please complete the survey above. When finished, click the green 'Next' button to continue with the experiment."
+        "instructionText": "Please complete the survey above. When finished, click the green 'Next' button to continue with the experiment."
     }
 
-Some external websites require specific names for URL query parameters. In this case, researchers can use the `generateProperties` parameter to dynamically create an iframe URL that uses custom names for the child and response query parameters. In the example below, the `generateProperties` function generates the `iframeSrc` value during each session by combining the base URL ("https://example.com") with two query parameters: one called 'a1', which contains the child ID, and one called 'a2', which contains the response ID. This same approach can be used to add any other information to the iframe URL query parameters using the information that the `generatePropeties` function has access to, such as the randomized condition, previous responses, and child's demographics (language, gender, age etc.).
+Some external websites require specific names for URL query parameters. In this case, researchers can use the `generateProperties` 
+parameter to dynamically create an iframe URL that uses custom names for the child and response query parameters. In the example below, 
+the `generateProperties` function generates the `iframeSrc` value during each session by combining the base URL ("https://example.com") 
+with two query parameters: one called 'a1', which contains the child ID, and one called 'a2', which contains the response ID. This same 
+approach can be used to add any other information to the iframe URL query parameters using the information that the `generateProperties` 
+function has access to, such as the randomized condition, previous responses, and child's demographics (language, gender, age etc.).
 
 .. code:: javascript
 
@@ -74,8 +77,21 @@ Some external websites require specific names for URL query parameters. In this 
         "kind": "exp-lookit-iframe",
         "iframeHeight": "1000px",
         "iframeWidth": "100%",
-        "optionalText": "Please schedule a time to participate. When you are finished, click the green 'Next' button to move on.",
+        "instructionText": "Please schedule a time to participate. When you are finished, click the green 'Next' button to move on.",
         "generateProperties": "function(expData, sequence, child, pastSessions, conditions) { return { 'iframeSrc': `https://example.com?a1=${pastSessions[0].get('hash_child_id')}&a2=${pastSessions[0].get('id')}` }; }"
+    }
+
+Here's an example of how to set the warning message.
+
+.. code:: javascript
+
+    "embedded-survey": {
+        "kind": "exp-lookit-iframe",
+        "iframeSrc": "https://example.com",
+        "iframeHeight": "700px",
+        "iframeWidth": "100%",
+        "instructionText": "Please complete the survey above. When finished, click the green 'Next' button to continue with the experiment.",
+        "warningMessageText": "Please confirm that you have finished the survey above before continuing to the next part of the study. You should see a screen that says 'Thank you, your response has been recorded'."
     }
 
 Parameters
@@ -97,15 +113,24 @@ iframeHeight [String | ``700px``]
 iframeWidth [String | ``100%``]
     Set the width of the iframe. You can use CSS units, including percents ("700px", "4in", "100%").
 
-optionalText [String]
-    Add a message underneath the iframe to contextualize what's being displayed. For instance, you can tell the participant how they 
+instructionText [String]
+    Add a message above the iframe to contextualize what's being displayed. For instance, you can tell the participant how they 
     will know when to click the Next button.
 
 optionalExternalLink [Boolean | ``false``]
     Allow participants to click on a link to open the external URL in a new tab if the iframe doesn't load correctly. This 
-    message displays under any optionalText string and reads "If you don't see anything in the space above, there might have 
+    message displays under the iframe and reads "If you don't see anything in the space above, there might have 
     been a problem loading this part of the study. Click [here] to open this part of the study in a new tab. Make sure to keep 
     this tab open so you can continue to the rest of the study."
+
+nextButtonText [String | ``Next`` ]
+    Text to display on the 'next frame' button.
+
+warningMessageText [String | ``Please confirm that you have finished the task above! When you have finished, click the button to continue.``]
+    Red text displayed above next button to confirm that the user understands that there's a task above to be completed before moving 
+    to next frame. If no value is given, the default text (shown above) will be used, otherwise you can provide a custom message. This 
+    message will appear after the user first clicks the 'Next' button, at which point the 'Next' button will be briefly disabled to 
+    encourage users to check that they've finished the iframe task and are clicking the correct button.
 
 Data collected
 ----------------

--- a/app/components/exp-lookit-iframe/template.hbs
+++ b/app/components/exp-lookit-iframe/template.hbs
@@ -1,20 +1,23 @@
-<iframe 
-    height={{ iframeHeight }} 
-    width={{ iframeWidth }} 
-    src={{ iframeSrc }} 
-    sandbox="allow-scripts allow-same-origin allow-forms"
-    referrerpolicy="no-referrer"
-></iframe>
-{{#if optionalText }}<p>{{ optionalText }}</p>{{/if}}
-{{#if optionalExternalLink }}
-    <p>
-        If you don't see anything in the space above, there might have been a problem loading this part of the study. Click 
-        <a href={{ iframeSrc }} target="_blank" rel="noopener noreferrer">here</a>
-        to open this part of the study in a new tab. Make sure to keep this tab open so you can continue to the rest of the study.
-    </p>
-{{/if}}
-<div class="row exp-controls">
-    <div class="col-md-12">
-        <button type="button" id="nextbutton" disabled="" class="btn btn-success pull-right" {{ action "next" }} > {{ t "Next" }} </button>
+<div class="exp-lookit-iframe">
+    {{#if instructionText }}<p>{{ instructionText }}</p>{{/if}}
+    <iframe
+        height={{ iframeHeight }}
+        width={{ iframeWidth }}
+        src={{ iframeSrc }}
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        referrerpolicy="no-referrer"
+    ></iframe>
+    {{#if optionalExternalLink }}
+        <p>
+            If you don't see anything in the space above, there might have been a problem loading this part of the study. Click 
+            <a href={{ iframeSrc }} target="_blank" rel="noopener noreferrer">here</a>
+            to open this part of the study in a new tab. Make sure to keep this tab open so you can continue to the rest of the study.
+        </p>
+    {{/if}}
+    <div class="center-text" id="warningmessage"><p class="warning">{{ warningMessageText }}</p></div>
+    <div class="row exp-controls">
+        <div class="col-md-12">
+            <button type="button" id="nextbutton" disabled="" class="btn btn-success pull-right next" > {{exp-format nextButtonText}} </button>
+        </div>
     </div>
 </div>

--- a/app/components/exp-lookit-iframe/template.hbs
+++ b/app/components/exp-lookit-iframe/template.hbs
@@ -14,7 +14,7 @@
             to open this part of the study in a new tab. Make sure to keep this tab open so you can continue to the rest of the study.
         </p>
     {{/if}}
-    <div class="center-text" id="warningmessage"><p class="warning">{{ warningMessageText }}</p></div>
+    <div class="center-text" id="warningmessage"><p>{{ warningMessageText }}</p></div>
     <div class="row exp-controls">
         <div class="col-md-12">
             <button type="button" id="nextbutton" disabled="" class="btn btn-success pull-right next" > {{exp-format nextButtonText}} </button>

--- a/app/components/exp-lookit-video-assent/template.hbs
+++ b/app/components/exp-lookit-video-assent/template.hbs
@@ -33,20 +33,26 @@
 
                 <div class="exp-lookit-assent-visual-container">
 
-                    {{#if currentPage.imgSrc}}
-                        <img class="exp-lookit-assent-image" src={{currentPage.imgSrc}} alt={{currentPage.altText}}>
-                    {{/if}}
-
                     <div class="row recorder-container {{unless currentPage.showWebcam "hidden-webcam"}}">
                         <div id="recorder" class="col-xs-12"></div>
                     </div>
 
-                    <video id="assent-video" class="exp-lookit-assent-image {{unless currentPage.video "hidden"}}" controls onended={{action "videoCompleted"}}>
-                        {{#each currentPage.video as |vidsource|}}
-                            <source src={{vidsource.src}} type={{vidsource.type}}>
-                        {{/each}}
-                        Your browser does not support the video tag.
-                    </video>
+                    {{#if recorderInitializing}} ({{t "please wait, setting up" }}...)
+
+                    {{else}}
+
+                        {{#if currentPage.imgSrc}}
+                            <img class="exp-lookit-assent-image" src={{currentPage.imgSrc}} alt={{currentPage.altText}}>
+                        {{/if}}
+
+                        <video id="assent-video" class="exp-lookit-assent-image {{unless currentPage.video "hidden"}}" controls onended={{action "videoCompleted"}}>
+                            {{#each currentPage.video as |vidsource|}}
+                                <source src={{vidsource.src}} type={{vidsource.type}}>
+                            {{/each}}
+                            Your browser does not support the video tag.
+                        </video>
+
+                    {{/if}}
 
                 </div>
 

--- a/app/components/exp-lookit-video-consent/component.js
+++ b/app/components/exp-lookit-video-consent/component.js
@@ -40,8 +40,8 @@ The consent document can be downloaded as PDF document by participant.
 export default ExpFrameBaseComponent.extend(VideoRecord, {
     layout: layout,
     frameType: 'CONSENT',
-    disableRecord: Em.computed('recorder.recording', 'recorder.hasCamAccess', function () {
-        return !this.get('recorder.hasCamAccess') || this.get('recorder.recording');
+    disableRecord: Em.computed('recorder.recording', 'recorder.hasCamAccess', 'recorderReady', function () {
+        return !(this.get('recorder.hasCamAccess') && this.recorderReady && !this.get('recorder.recording'));
     }),
     startedRecording: false,
     hasCheckedVideo: false,
@@ -641,7 +641,7 @@ export default ExpFrameBaseComponent.extend(VideoRecord, {
         this.set('consentFormText', $('#consent-form-text').text());
         $('#recordingIndicator').hide();
         $('#recordingText').text(this._translate('exp-lookit-video-consent.Not-recording-yet'));
-        $('#recordbutton').prop('disabled', false);
+        $('#recordbutton').prop('disabled', true);
         $('#stopbutton').prop('disabled', true);
         $('#playbutton').prop('disabled', true);
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -25,6 +25,7 @@
 @import "components/exp-lookit-instruction-video";
 @import "components/exp-lookit-survey-consent";
 @import "components/consent-garden";
+@import "components/exp-lookit-iframe";
 
 #experiment-player {
     font-size: large;

--- a/app/styles/components/exp-lookit-iframe.scss
+++ b/app/styles/components/exp-lookit-iframe.scss
@@ -1,8 +1,7 @@
 .exp-lookit-iframe {
-    .warning {
-        color: red;
-    }
     #warningmessage {
-        visibility: hidden
+        visibility: hidden;
+        overflow-wrap: break-word;
+        color: red;
     }
 }

--- a/app/styles/components/exp-lookit-iframe.scss
+++ b/app/styles/components/exp-lookit-iframe.scss
@@ -1,0 +1,8 @@
+.exp-lookit-iframe {
+    .warning {
+        color: red;
+    }
+    #warningmessage {
+        visibility: hidden
+    }
+}


### PR DESCRIPTION
# Summary

This PR moves the changes onto the EFP master branch, so that this version becomes the default experiment runner version on production.

- `iframe` updates: #385
  - Add a parameter for `nextButtonText` to allow researchers to modify the "Next" button text.
  - Add a red warning message that appears above the next button after the first time it's clicked, asking participants to confirm that they've finished the iframe task before clicking this button. This text can be modified by researchers with the `warningMessageText` parameter.
  - Briefly disable the "Next" button after it's first clicked (so that participants have a chance to see/read the warning message and cannot accidentally move on before finishing).
  - Rename `optionalText` to `instructionText` and display it above (rather than below) the iframe.
- `iframe` documentation updates related to the above changes. #391
- Bug fixes in the `video-consent` and `video-assent` frames to prevent participants from being able to start their consent recording before the recorder is ready. This fixes a problem where participants produced a blank consent video and were able to continue on with the experiment. #388