### PR TITLE
Wait for recorder to fully stop before completing upload

### DIFF
--- a/app/components/exp-lookit-video-assent/template.hbs
+++ b/app/components/exp-lookit-video-assent/template.hbs
@@ -37,7 +37,9 @@
                         <div id="recorder" class="col-xs-12"></div>
                     </div>
 
-                    {{#if recorderInitializing}} ({{t "please wait, setting up" }}...)
+                    {{#if recorderInitializing}}
+
+                        ({{t "please wait, setting up" }}...)
 
                     {{else}}
 

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -403,7 +403,10 @@ export default Ember.Mixin.create({
                 $('.video-record-mixin-wait-for-video-text').html(`${expFormat(this.get('waitForUploadMessage'))}`);
                 this.showWaitForVideoCover();
             }
-            return recorder.stop(this.get('maxUploadSeconds') * 1000);
+            return recorder.stop(this.get('maxUploadSeconds') * 1000)
+                .catch((e) => {
+                    throw new Error(`Error stopping recorder and uploading: ${e}`);
+                });
         } else {
             // reject the promise because the recorder is in one of the following states:
             // - doesn't exist, or is not recording, or has been destroyed

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -444,6 +444,7 @@ export default Ember.Mixin.create({
             .catch((err) => {
                 console.error(`Error playing video: ${err.name}: ${err.message}`);
                 console.trace();
+                throw new Error('Error playing video');
             });
     },
 

--- a/app/services/s3.js
+++ b/app/services/s3.js
@@ -32,7 +32,11 @@ class S3 {
             Bucket: this.env.bucket,
             Key: this.key,
             ContentType: "video/webm",
-        }).promise();
+        }).promise()
+            .catch((e) => {
+                this.logRecordingEvent(`Error creating upload: ${e}`);
+                throw new Error(`Error creating upload: ${e}`);
+            });
         this.uploadId = createResponse.UploadId;
         this.logRecordingEvent(`Connection established.`);
     }
@@ -81,6 +85,10 @@ class S3 {
         }).promise()
             .then((resp) => {
                 this.logRecordingEvent(`Upload complete: ${resp.Location}`);
+            })
+            .catch((e) => {
+                this.logRecordingEvent(`Error completing upload: ${e}`);
+                throw new Error(`Error completing upload: ${e}`);
             });
     }
 

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -458,7 +458,7 @@ const VideoRecorder = Ember.Object.extend({
         var recorder = this.get('recorder');
         if (recorder) {
             try {
-                recorder.stopRecording();
+                await recorder.stopRecording();
                 _this.get('recorder').onRecordingStopped.call(_this);
                 await this.get('s3').completeUpload();
                 _this._onUploadDone(this.get('recorderId'), this.get('s3').key); // clears the upload timeout, sets isUploaded to true, resolves stop promise

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -354,7 +354,7 @@ const VideoRecorder = Ember.Object.extend({
             const catch_install_error = (err) => {
                 console.error(`Recorder installation error:\n${err.name}: ${err.message}`);
                 console.trace();
-                return reject();
+                throw new Error(`Recorder installation error: ${err}`);
             }
 
             navigator.mediaDevices.getUserMedia({audio: {noiseSuppression: true}, video: {width: 1280, height: 720, frameRate: 30}})

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -347,7 +347,7 @@ const VideoRecorder = Ember.Object.extend({
                         resolve(); // skip mic check and resolve the install promise
                     }
                 } else {
-                    reject();
+                    reject(new Error(`Mic check error: no input stream.`));
                 }
             };
 

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -464,6 +464,7 @@ const VideoRecorder = Ember.Object.extend({
                 _this._onUploadDone(this.get('recorderId'), this.get('s3').key); // clears the upload timeout, sets isUploaded to true, resolves stop promise
             } catch (e) {
                 console.warn(`Error stopping video ${_this.get('videoName')}: ${e}`);
+                throw new Error('Error stopping video.');
             }
         }
         return _stopPromise;
@@ -477,7 +478,7 @@ const VideoRecorder = Ember.Object.extend({
      */
     pause() {
         this.get('recorder').getState().then((curr_state) => {
-            return new RSVP.Promise((resolve, reject) => {
+            return new RSVP.Promise((resolve) => {
                 if (curr_state == "recording") {
                     this.get('recorder').pauseRecording()
                         .then(() => {
@@ -486,7 +487,7 @@ const VideoRecorder = Ember.Object.extend({
                         .catch((err) => {
                             console.error(`Error pausing recorder:\n${err.name}: ${err.message}`);
                             console.trace();
-                            reject();
+                            throw new Error('Error pausing recorder');
                         });
                 } else {
                     resolve();
@@ -503,7 +504,7 @@ const VideoRecorder = Ember.Object.extend({
      */
     resume() {
         this.get('recorder').getState().then((curr_state) => {
-            return new RSVP.Promise((resolve, reject) => {
+            return new RSVP.Promise((resolve) => {
                 if (curr_state == "paused") {
                     this.get('recorder').resumeRecording()
                         .then(() => {
@@ -512,7 +513,7 @@ const VideoRecorder = Ember.Object.extend({
                         .catch((err) => {
                             console.error(`Error resuming recording:\n${err.name}: ${err.message}`);
                             console.trace();
-                            reject();
+                            throw new Error('Error resuming recorder');
                         });
                 } else {
                     resolve();


### PR DESCRIPTION
## Summary

### 1. Waiting for the recorder to stop before completing the upload

This PR adds an `await` to RecordRTC's [`stopRecording` method](https://recordrtc.org/RecordRTC.js.html#line5730). This function returns a promise, but we were not waiting for that promise to resolve before calling S3's complete upload function. This _might_ be the reason for the video files that have been cut off at the end: #392. The critical change is in `app/services/video-recorder.js` line 461:

```js
await recorder.stopRecording();
```
I can't confirm that this will fix the issue, because I can't reproduce the video recording clipping problem. But I'm confident that this change should not introduce any new problems.

**A little more context:**

Under the hood, the RecordRTC recorder's `stopRecording` method calls the web api [media recorder `stop` method](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/stop) and returns a promise. The web api stop method needs to trigger the 'data available' event one last time before actually stopping, so that the last bit of data can be saved. Our own recorder's `stop` method was correctly async and waited for the upload to complete before resolving, but did not wait for the recorder's stop method to resolve before starting to complete the upload. So it's possible that there's a small bit of data that's missed when we moved on from stopping the recorder to completing the upload. If so, this would explain why the recordings are only ever clipped a little bit and by a variable amount.

**Dev question:**

Why wouldn't we be seeing errors when that last data available callback is called _after_ the upload completion process has started?

### 2. Error catching/logging

This PR also throws some more informative errors, instead of just rejecting promises, so that we can get more helpful errors in Sentry. In general, if a promise needs to be explicitly rejected, then it needs to include a reason (otherwise we get an "Uncaught (in promise) undefined" error), and best practices are to actually throw an error as the reason. In places where we're using a catch block instead of calling `reject`, we can just throw an error (because the promise has already been rejected at that point).

This improved error catching/logging is especially useful for differentiating video recording problems where something has gone wrong on our end, vs something that has happened on the participant's end that we have no control over (e.g. internet connection is disrupted). Right now, those cases are mixed together, both for researchers and for us (in Sentry).

**Question:**

What would we like the experiment runner to do when the maximum upload duration has been reached? My guess is that the experiment should not stop with an error, but rather should continue on as though the file has successfully uploaded? And that we want error logging both in Sentry and in the experiment data?