### PR TITLE
await recorder stop promise (#393)

### DIFF
--- a/app/components/exp-lookit-video-assent/template.hbs
+++ b/app/components/exp-lookit-video-assent/template.hbs
@@ -37,7 +37,9 @@
                         <div id="recorder" class="col-xs-12"></div>
                     </div>
 
-                    {{#if recorderInitializing}} ({{t "please wait, setting up" }}...)
+                    {{#if recorderInitializing}}
+
+                        ({{t "please wait, setting up" }}...)
 
                     {{else}}
 

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -403,7 +403,10 @@ export default Ember.Mixin.create({
                 $('.video-record-mixin-wait-for-video-text').html(`${expFormat(this.get('waitForUploadMessage'))}`);
                 this.showWaitForVideoCover();
             }
-            return recorder.stop(this.get('maxUploadSeconds') * 1000);
+            return recorder.stop(this.get('maxUploadSeconds') * 1000)
+                .catch((e) => {
+                    throw new Error(`Error stopping recorder and uploading: ${e}`);
+                });
         } else {
             // reject the promise because the recorder is in one of the following states:
             // - doesn't exist, or is not recording, or has been destroyed
@@ -444,6 +447,7 @@ export default Ember.Mixin.create({
             .catch((err) => {
                 console.error(`Error playing video: ${err.name}: ${err.message}`);
                 console.trace();
+                throw new Error('Error playing video');
             });
     },
 

--- a/app/services/s3.js
+++ b/app/services/s3.js
@@ -32,7 +32,11 @@ class S3 {
             Bucket: this.env.bucket,
             Key: this.key,
             ContentType: "video/webm",
-        }).promise();
+        }).promise()
+            .catch((e) => {
+                this.logRecordingEvent(`Error creating upload: ${e}`);
+                throw new Error(`Error creating upload: ${e}`);
+            });
         this.uploadId = createResponse.UploadId;
         this.logRecordingEvent(`Connection established.`);
     }
@@ -81,6 +85,10 @@ class S3 {
         }).promise()
             .then((resp) => {
                 this.logRecordingEvent(`Upload complete: ${resp.Location}`);
+            })
+            .catch((e) => {
+                this.logRecordingEvent(`Error completing upload: ${e}`);
+                throw new Error(`Error completing upload: ${e}`);
             });
     }
 


### PR DESCRIPTION
This PR moves the following changes into the master branch (default version on production).

Critical change that may fix the clipped consent recordings issue (#392): 
* add await to RecordRTC stopRecording method

Other changes:
* throw errors for sentry logging
* add catch blocks to S3 create/complete upload promises and throw errors (to capture in Sentry)
* add catch block and throw error for recorder stop promise
* throw error in recorder install promise catch block rather than reject
* throw error in mic check reject case (fixes uncaught in promise error)
* fix template linting error - formatting/indentation