### PR TITLE
Fix video assent webcam display

### DIFF
--- a/app/components/exp-lookit-video-assent/doc.rst
+++ b/app/components/exp-lookit-video-assent/doc.rst
@@ -67,6 +67,11 @@ and data collected that come from the following more general sources:
 - :ref:`video-record`
 - :ref:`expand-assets`
 
+.. admonition:: Do not use with session recording
+    :class: warning
+
+    The video-assent frame is not meant to be used with simultaneous session recording. If you'd like to use session recording during your experiment, you should start the session recording *after* the video-assent frame.
+
 
 Example
 ----------------

--- a/app/components/exp-lookit-video-consent/doc.rst
+++ b/app/components/exp-lookit-video-consent/doc.rst
@@ -55,6 +55,10 @@ and data collected that come from the following more general sources:
 - :ref:`video-record`
 - :ref:`expand-assets`
 
+.. admonition:: Do not use with session recording
+    :class: warning
+
+    The video-consent frame is not meant to be used with simultaneous session recording. If you'd like to use session recording during your experiment, you should start the session recording *after* the video-consent frame.
 
 Example
 ----------------

--- a/app/styles/components/exp-lookit-video-assent.scss
+++ b/app/styles/components/exp-lookit-video-assent.scss
@@ -157,4 +157,8 @@ $exp-lookit-video-assent-highlight-color: #d4efdf;
         min-height: unset !important;
     }
 
+    .recorder-container #recorder {
+        width: 100%;
+    }
+
 }


### PR DESCRIPTION
Fixes #398

## Summary

This fixes a problem with the webcam display in the `video-assent` frame. This problem was introduced recently when I made changes to ensure that the video recorder was ready before the participant was able to start recording in the video-assent and video-consent frames (#388).

## Description of changes

- The check for camera/recorder use (`doUseCamera`) was only checking for `recordWholeProcedure` and `recordLastPage` - now it also checks to see whether any of the pages display the webcam feed.
- While testing this version, I noticed that the `whenPossibleToRecordObserver` could incorrectly trigger the next page more than and the logic was overly complicated. I simplified it so that now it only has an effect on the very first page (since we're just checking whether the recorder is ready at the start, to trigger the first page content). And now when the recorder is ready, the logic is simpler and less error-prone: it either just starts the recording (if recording should start automatically) or shows the first page content.
- Setting the recorder container's width centers it in the page content. This change only affects the video-assent frame.

## Testing

I've tested this in all of the recording/non-recording variations that were tested in #388:

- record whole procedure
- record last page
- no recording
- session recording (see 'Docs Updates' section)

As well as the recording-related parameter combinations involving webcam display:

- webcam shown on first page
- webcam shown on second page
- webcam shown on both pages
- webcam not shown

## Screenshots

Currently, when the `showWebcam: true` parameter setting is used, the frame does not the display the webcam feed as it should:

![Screenshot 2024-07-01 at 2 22 53 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/ae44783f-5545-48e7-97f3-689f4f1ee190)

This change fixes this so that the `showWebcam: true` setting works correctly:

![Screenshot 2024-07-01 at 2 22 05 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/284b50cd-973d-4cc3-912b-a884d185ce7c)

## Docs Updates

As part of testing, I noticed that the webcam display does not work when session recording is in progress. Getting that to work is non-trivial, as the session recorder is attached to a different part of the page (so that it keeps running across frames) and it is designed to stay hidden. Also, AFAIK there's no strong use case for using session recording during consent/assent frames. Therefore I've added a note to the docs to warn users not to use session recording _during_ the video-assent/consent frames, and instead to start session recording _after_ those frames.

**video assent docs page**

![Screenshot 2024-07-01 at 3 36 12 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/118645cd-c174-4816-bc48-32e736d23500)

**video consent docs page**

![Screenshot 2024-07-01 at 3 36 27 PM](https://github.com/lookit/ember-lookit-frameplayer/assets/9041788/23ccb87c-0fb2-402c-a2af-3fc6cc16fdb8)
