### PR TITLE
Fix video assent webcam display (#399)

### DIFF
--- a/app/components/exp-lookit-video-assent/doc.rst
+++ b/app/components/exp-lookit-video-assent/doc.rst
@@ -67,6 +67,11 @@ and data collected that come from the following more general sources:
 - :ref:`video-record`
 - :ref:`expand-assets`
 
+.. admonition:: Do not use with session recording
+    :class: warning
+
+    The video-assent frame is not meant to be used with simultaneous session recording. If you'd like to use session recording during your experiment, you should start the session recording *after* the video-assent frame.
+
 
 Example
 ----------------

--- a/app/components/exp-lookit-video-consent/doc.rst
+++ b/app/components/exp-lookit-video-consent/doc.rst
@@ -55,6 +55,10 @@ and data collected that come from the following more general sources:
 - :ref:`video-record`
 - :ref:`expand-assets`
 
+.. admonition:: Do not use with session recording
+    :class: warning
+
+    The video-consent frame is not meant to be used with simultaneous session recording. If you'd like to use session recording during your experiment, you should start the session recording *after* the video-consent frame.
 
 Example
 ----------------

--- a/app/styles/components/exp-lookit-video-assent.scss
+++ b/app/styles/components/exp-lookit-video-assent.scss
@@ -157,4 +157,8 @@ $exp-lookit-video-assent-highlight-color: #d4efdf;
         min-height: unset !important;
     }
 
+    .recorder-container #recorder {
+        width: 100%;
+    }
+
 }


### PR DESCRIPTION
This PR moves the following changes described in #399 into the `master` branch (default production version) of EFP, which fixes this issue about the webcam display not appearing in the video-assent frame in certain cases: #398. 

The main changes are:

* In the video-assent frame, check for webcam _display_ (not just recording) when determining whether camera will be used
* In the video-assent CSS, override the recorder container width (100% instead of auto) to center webcam display
* Add warnings in the video-assent/consent frame documentation about not running session recording during these frames