### PR TITLE
Add video ID to events that occur during recordings

### DIFF
--- a/app/components/exp-frame-base/component.js
+++ b/app/components/exp-frame-base/component.js
@@ -621,10 +621,11 @@ let ExpFrameBase = Ember.Component.extend(FullScreen, SessionRecord, {
             timestamp: curTime.toISOString()
         };
         Ember.assign(eventData, extra);
-        // Add some extra info if there's session recording ongoing
+        // Add some extra info if there's session recording in progress (stream time and video ID)
         if (this.get('sessionRecorder') && this.get('sessionRecordingInProgress')) {
             Ember.assign(eventData, {
-                sessionStreamTime: this.get('sessionRecorder').getTime()
+                sessionStreamTime: this.get('sessionRecorder').getTime(),
+                sessionVideoId: this.get('sessionRecorder').get('videoName')
             });
         }
         return eventData;

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -33,9 +33,7 @@ let {
  * See 'methods' for the functions you can use on a frame that extends SessionRecord.
  *
  * Events recorded in a frame that extends SessionRecord will automatically have additional
- * fields sessionVideoId (video filename), pipeId (temporary filename initially assigned by
- * the recording service),
- * and streamTime (when in the video they happened, in s).
+ * fields sessionVideoId (video filename), and streamTime (when in the video they happened, in s).
  *
  * @class Session-record
  */

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -160,14 +160,16 @@ export default Ember.Mixin.create({
             _this.get('sessionRecorder').set('hasCamAccess', hasAccess);
             if (!(_this.get('isDestroyed') || _this.get('isDestroying'))) {
                 _this.send('setTimeEvent', 'sessionRecorder.hasCamAccess', {
-                    hasCamAccess: hasAccess
+                    hasCamAccess: hasAccess,
+                    sessionVideoId: sessionVideoId,
                 });
             }
         });
         sessionRecorder.on('onConnectionStatus', (recId, status) => {   // eslint-disable-line no-unused-vars
             if (!(_this.get('isDestroyed') || _this.get('isDestroying'))) {
                 _this.send('setTimeEvent', 'videoStreamConnection', {
-                    status: status
+                    status: status,
+                    sessionVideoId: sessionVideoId
                 });
                 _this.notifyPropertyChange('whenPossibleToRecordSession');
             }
@@ -194,9 +196,7 @@ export default Ember.Mixin.create({
                  *
                  * @event startSessionRecording
                  */
-                _this.send('setTimeEvent', 'startSessionRecording', {
-                    sessionPipeId: sessionRecorder.get('videoName')
-                });
+                _this.send('setTimeEvent', 'startSessionRecording');
             });
         } else {
             return Ember.RSVP.reject();
@@ -217,7 +217,9 @@ export default Ember.Mixin.create({
              * @event stopSessionRecording
              */
             this.get('session').set('recordingInProgress',false);
-            this.send('setTimeEvent', 'stopSessionRecording');
+            this.send('setTimeEvent', 'stopSessionRecording', {
+                sessionVideoId: this.get('session').get('videoId')
+            });
             return sessionRecorder.stop(this.get('sessionMaxUploadSeconds') * 1000);
         } else {
             return Ember.RSVP.reject();
@@ -232,7 +234,9 @@ export default Ember.Mixin.create({
         const recorder = this.get('sessionRecorder');
         if (recorder) {
             if (!(this.get('isDestroyed') || this.get('isDestroying'))) {
-                this.send('setTimeEvent', 'destroyingRecorder');
+                this.send('setTimeEvent', 'destroyingRecorder', {
+                    sessionVideoId: this.get('session').get('videoId')
+                });
             }
             recorder.destroy();
             $(`#${this.get('sessionRecorderElement')}`).remove();
@@ -249,7 +253,9 @@ export default Ember.Mixin.create({
                  *
                  * @event sessionRecorderReady
                  */
-                _this.send('setTimeEvent', 'sessionRecorderReady');
+                _this.send('setTimeEvent', 'sessionRecorderReady', {
+                    sessionVideoId: this.get('session').get('videoId')
+                });
                 _this.get('session').set('recordingInProgress', true);
                 _this.set('sessionRecorderReady', true);
                 _this.whenPossibleToRecordSessionObserver(); // make sure this fires

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -52,8 +52,7 @@ let {
  * See 'methods' for the functions you can use on a frame that extends VideoRecord.
  *
  * Events recorded in a frame that extends VideoRecord will automatically have additional
- * fields videoId (video filename), pipeId (temporary filename initially assigned by
- * the recording service), and streamTime (when in the video they happened, in s).
+ * fields videoId (video filename) and streamTime (when in the video they happened, in s).
  *
  * Setting up the camera is handled in didInsertElement, and making sure recording is
  * stopped is handled in willDestroyElement (Ember hooks that fire during the component

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -295,11 +295,14 @@ export default Ember.Mixin.create({
      * @return {Object} Event data object
      */
     makeTimeEvent(eventName, extra) {
-        // All frames using this mixin will add streamTime to every server event
+        // All frames using this mixin will add streamTime and video ID to every event
         let base = this._super(eventName, extra);
-        Ember.assign(base, {
-            streamTime: this.get('recorder') ? this.get('recorder').getTime() : null
-        });
+        if (this.get('recorder') && this.get('videoId')) {
+            Ember.assign(base, {
+                streamTime: this.get('recorder').getTime(),
+                videoId: this.get('videoId')
+            });
+        }
         return base;
     },
 
@@ -342,9 +345,7 @@ export default Ember.Mixin.create({
             }
         });
         this.set('recorder', recorder);
-        this.send('setTimeEvent', 'setupVideoRecorder', {
-            videoId: videoId
-        });
+        this.send('setTimeEvent', 'setupVideoRecorder');
         
         return installPromise;
     },
@@ -359,9 +360,7 @@ export default Ember.Mixin.create({
         var _this = this;
         if (recorder) {
             return recorder.record().then(() => {
-                this.send('setTimeEvent', 'startRecording', {
-                    pipeId: recorder.get('videoName') // TO DO: change 'pipeId' to something else 
-                });
+                this.send('setTimeEvent', 'startRecording');
                 if (this.get('videoList') == null) {
                     this.set('videoList', [this.get('videoId')]);
                 } else {

--- a/app/mixins/video-record.rst
+++ b/app/mixins/video-record.rst
@@ -130,8 +130,8 @@ If your frame uses the video-record mixin, you may see the following in addition
 
 :startRecording: When video recorder has actually started recording
 
-    :pipeId: [String] Original filename assigned by the Pipe client. May be used for troubleshooting.
-
 :stoppingCapture: Just before stopping webcam video capture
 
 :destroyingRecorder: When video recorder is about to be destroyed before next frame
+
+All video-related events should include the ``videoId`` (video filename).


### PR DESCRIPTION
This PR automatically adds video IDs to video/session recording events, so that video filenames are always added to events that occur while recording is in progress (and certain setup/teardown events).

This change is part of ongoing work to improve our event logging in the researcher's data related to video recording/uploading issues: #395, #383, #397, as well as reducing Sentry error logs: #358. For these issues, I'm adding new events to the researcher data, so it's helpful to streamline the recording-related events to include always video filenames.

This PR also changes the file name properties in the `startSessionRecording` and `startRecording` from `sessionPipeId` and `pipeId` to `sessionVideoId` and `videoId`. The former names were a hangover from the old Pipe recording system and were inconsistent with the `videoId`/`sessionVideoId` filename property names that are currently used in other events. 

**Implementation notes**

The video-record mixin always adds the filename and stream time info to events. 

However, when the session-record mixin is used, we only add the video filename and stream time if _recording is in progress_. This is because the session recorder continues to exist on subsequent frames after session recording has stopped, so it is confusing to see the session recording filename in events after the session recording has stopped. I've also added the session video filename manually to specific setup/teardown events where it could be helpful for searching/debugging purposes. (Another option is to actually destroy the session recorder and set it to `null` so that it is not detected during events on subsequent frames, but this is a change that requires a little more testing to make sure it doesn't break anything).