### PR TITLE
Add error catching/logging for recording start and stop/upload problems

### DIFF
--- a/app/components/exp-frame-base/component.js
+++ b/app/components/exp-frame-base/component.js
@@ -621,10 +621,11 @@ let ExpFrameBase = Ember.Component.extend(FullScreen, SessionRecord, {
             timestamp: curTime.toISOString()
         };
         Ember.assign(eventData, extra);
-        // Add some extra info if there's session recording ongoing
+        // Add some extra info if there's session recording in progress (stream time and video ID)
         if (this.get('sessionRecorder') && this.get('sessionRecordingInProgress')) {
             Ember.assign(eventData, {
-                sessionStreamTime: this.get('sessionRecorder').getTime()
+                sessionStreamTime: this.get('sessionRecorder').getTime(),
+                sessionVideoId: this.get('sessionRecorder').get('videoName')
             });
         }
         return eventData;

--- a/app/components/exp-frame-base/component.js
+++ b/app/components/exp-frame-base/component.js
@@ -714,9 +714,13 @@ let ExpFrameBase = Ember.Component.extend(FullScreen, SessionRecord, {
                     _this.sendAction('next', frameIndex);
                 } else {
                     this.get('session').set('recordingInProgress', false);
-                    this.stopSessionRecorder().finally(() => {
-                        _this.sendAction('next', frameIndex);
-                    });
+                    // Error catching/logging for stopping/upload problems is
+                    // handled inside stopSessionRecorder. The finally callback ensures that the
+                    // participant moves on after the stop promise is no longer pending.
+                    this.stopSessionRecorder()
+                        .finally(() => {
+                            _this.sendAction('next', frameIndex);
+                        });
                 }
             } else {
                 this.sendAction('next', frameIndex);

--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -99,7 +99,6 @@ export default Ember.Component.extend(FullScreen, {
     stopAndDestroyRecorders() {
         // Stop/destroy session recorder if needed
         if (this.get('session').get('recorder')) {
-            console.log('try to upload session recording');
             var sessionRecorder = this.get('session').get('recorder');
             this.get('session').set('recordingInProgress', false);
             if (sessionRecorder.get('recording')) {
@@ -113,7 +112,6 @@ export default Ember.Component.extend(FullScreen, {
 
         // stop/destroy trial recorder if needed
         if (this.get('recorder') && this.get('recorder').get('recording')) {
-            console.log('try to upload trial recording');
             this.stopRecorder().finally(() => {
                 this.destroyRecorder();
             });

--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -96,6 +96,30 @@ export default Ember.Component.extend(FullScreen, {
             });
     },
 
+    stopAndDestroyRecorders() {
+        // Stop/destroy session recorder if needed
+        if (this.get('session').get('recorder')) {
+            console.log('try to upload session recording');
+            var sessionRecorder = this.get('session').get('recorder');
+            this.get('session').set('recordingInProgress', false);
+            if (sessionRecorder.get('recording')) {
+                sessionRecorder.stop().finally(() => {
+                    sessionRecorder.destroy();
+                });
+            } else {
+                sessionRecorder.destroy();
+            }
+        }
+
+        // stop/destroy trial recorder if needed
+        if (this.get('recorder') && this.get('recorder').get('recording')) {
+            console.log('try to upload trial recording');
+            this.stopRecorder().finally(() => {
+                this.destroyRecorder();
+            });
+        }
+    },
+
     _registerHandlers() {
         $(window).on('beforeunload', this.beforeUnload.bind(this));
         var _this = this;
@@ -260,18 +284,8 @@ export default Ember.Component.extend(FullScreen, {
         },
 
         exitEarly() {
-            // Stop/destroy session recorder if needed
-            if (this.get('session').get('recorder')) {
-                var sessionRecorder = this.get('session').get('recorder');
-                this.get('session').set('recordingInProgress', false);
-                if (sessionRecorder.get('recording')) {
-                    sessionRecorder.stop().finally(() => {
-                        sessionRecorder.destroy();
-                    });
-                } else {
-                    sessionRecorder.destroy();
-                }
-            }
+
+            this.stopAndDestroyRecorders();
 
             Ember.$(window).off('keydown');
             // Save any available data immediately

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -33,9 +33,7 @@ let {
  * See 'methods' for the functions you can use on a frame that extends SessionRecord.
  *
  * Events recorded in a frame that extends SessionRecord will automatically have additional
- * fields sessionVideoId (video filename), pipeId (temporary filename initially assigned by
- * the recording service),
- * and streamTime (when in the video they happened, in s).
+ * fields sessionVideoId (video filename), and streamTime (when in the video they happened, in s).
  *
  * @class Session-record
  */

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -201,7 +201,7 @@ export default Ember.Mixin.create({
                  * @event startSessionRecording
                  */
                 _this.send('setTimeEvent', 'startSessionRecording');
-            });
+                });
         } else {
             return Ember.RSVP.reject(new Error('Must call setupSessionRecorder before startSessionRecorder'));
         }
@@ -237,7 +237,7 @@ export default Ember.Mixin.create({
                     // This block catches upload timeouts and any other errors related to stopping the recorder or uploading the data.
                     // This session recorder stop promise rejection will not cause the experiment to stop with an error,
                     // because the code waiting on this promise is in a "finally" block (rather than "then").
-                    if (e == 'uploadTimedout') {
+                    if (e.message == 'uploadTimedout') {
                         this.send('setTimeEvent', 'sessionRecordingUploadTimedout', {
                             sessionVideoId: this.get('session').get('videoId')
                         });

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -205,7 +205,7 @@ export default Ember.Mixin.create({
                 })
                 .catch((err) => {
                     this.send('setTimeEvent', 'errorStartingSessionRecording', {
-                        error: err
+                        error: err.message
                     });
                     console.error(`Error starting session recording for file: ${_this.get('session').get('videoId')}\n${err.name}: ${err.message}`);
                     throw new Error(`Error starting session recording for file: ${_this.get('session').get('videoId')}\n${err.name}: ${err.message}`)
@@ -251,7 +251,7 @@ export default Ember.Mixin.create({
                         });
                     } else {
                         this.send('setTimeEvent', 'errorStoppingSessionRecording', {
-                            error: e,
+                            error: e.message,
                             sessionVideoId: this.get('session').get('videoId')
                         });
                         throw new Error(`Error stopping session recorder and uploading: ${e}`);

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -160,14 +160,16 @@ export default Ember.Mixin.create({
             _this.get('sessionRecorder').set('hasCamAccess', hasAccess);
             if (!(_this.get('isDestroyed') || _this.get('isDestroying'))) {
                 _this.send('setTimeEvent', 'sessionRecorder.hasCamAccess', {
-                    hasCamAccess: hasAccess
+                    hasCamAccess: hasAccess,
+                    sessionVideoId: sessionVideoId,
                 });
             }
         });
         sessionRecorder.on('onConnectionStatus', (recId, status) => {   // eslint-disable-line no-unused-vars
             if (!(_this.get('isDestroyed') || _this.get('isDestroying'))) {
                 _this.send('setTimeEvent', 'videoStreamConnection', {
-                    status: status
+                    status: status,
+                    sessionVideoId: sessionVideoId
                 });
                 _this.notifyPropertyChange('whenPossibleToRecordSession');
             }
@@ -194,9 +196,7 @@ export default Ember.Mixin.create({
                  *
                  * @event startSessionRecording
                  */
-                _this.send('setTimeEvent', 'startSessionRecording', {
-                    sessionPipeId: sessionRecorder.get('videoName')
-                });
+                _this.send('setTimeEvent', 'startSessionRecording');
             });
         } else {
             return Ember.RSVP.reject();
@@ -217,7 +217,9 @@ export default Ember.Mixin.create({
              * @event stopSessionRecording
              */
             this.get('session').set('recordingInProgress',false);
-            this.send('setTimeEvent', 'stopSessionRecording');
+            this.send('setTimeEvent', 'stopSessionRecording', {
+                sessionVideoId: this.get('session').get('videoId')
+            });
             return sessionRecorder.stop(this.get('sessionMaxUploadSeconds') * 1000);
         } else {
             return Ember.RSVP.reject();
@@ -232,7 +234,9 @@ export default Ember.Mixin.create({
         const recorder = this.get('sessionRecorder');
         if (recorder) {
             if (!(this.get('isDestroyed') || this.get('isDestroying'))) {
-                this.send('setTimeEvent', 'destroyingRecorder');
+                this.send('setTimeEvent', 'destroyingRecorder', {
+                    sessionVideoId: this.get('session').get('videoId')
+                });
             }
             recorder.destroy();
             $(`#${this.get('sessionRecorderElement')}`).remove();
@@ -249,7 +253,9 @@ export default Ember.Mixin.create({
                  *
                  * @event sessionRecorderReady
                  */
-                _this.send('setTimeEvent', 'sessionRecorderReady');
+                _this.send('setTimeEvent', 'sessionRecorderReady', {
+                    sessionVideoId: this.get('session').get('videoId')
+                });
                 _this.get('session').set('recordingInProgress', true);
                 _this.set('sessionRecorderReady', true);
                 _this.whenPossibleToRecordSessionObserver(); // make sure this fires

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -194,13 +194,21 @@ export default Ember.Mixin.create({
         const sessionRecorder = this.get('sessionRecorder');
         if (sessionRecorder) {
             var _this = this;
-            return sessionRecorder.record().then(() => {
-                /**
-                 * When session video recorder has begun recording
-                 *
-                 * @event startSessionRecording
-                 */
-                _this.send('setTimeEvent', 'startSessionRecording');
+            return sessionRecorder.record()
+                .then(() => {
+                    /**
+                     * When session video recorder has begun recording
+                     *
+                     * @event startSessionRecording
+                     */
+                    _this.send('setTimeEvent', 'startSessionRecording');
+                })
+                .catch((err) => {
+                    this.send('setTimeEvent', 'errorStartingSessionRecording', {
+                        error: err
+                    });
+                    console.error(`Error starting session recording for file: ${_this.get('session').get('videoId')}\n${err.name}: ${err.message}`);
+                    throw new Error(`Error starting session recording for file: ${_this.get('session').get('videoId')}\n${err.name}: ${err.message}`)
                 });
         } else {
             return Ember.RSVP.reject(new Error('Must call setupSessionRecorder before startSessionRecorder'));

--- a/app/mixins/session-record.js
+++ b/app/mixins/session-record.js
@@ -117,6 +117,12 @@ export default Ember.Mixin.create({
     */
     _starting: false,
 
+    /**
+     * Private flag that is set when the async stopRecording method is first called
+     * to prevent record from being called multiple times
+    */
+    _stopping: false,
+
     _generateSessionVideoId() {
         return [
             'videoStream',
@@ -197,7 +203,7 @@ export default Ember.Mixin.create({
                 _this.send('setTimeEvent', 'startSessionRecording');
             });
         } else {
-            return Ember.RSVP.reject();
+            return Ember.RSVP.reject(new Error('Must call setupSessionRecorder before startSessionRecorder'));
         }
     },
 
@@ -208,7 +214,8 @@ export default Ember.Mixin.create({
      */
     stopSessionRecorder() {
         const sessionRecorder = this.get('sessionRecorder');
-        if (sessionRecorder) {
+        if (sessionRecorder && this.get('session').get('recordingInProgress') && !(this.get('_stopping'))) {
+            this.set('_stopping', true);
             /**
              * When session video recorder is stopped (upload may continue afterwards)
              *
@@ -218,9 +225,35 @@ export default Ember.Mixin.create({
             this.send('setTimeEvent', 'stopSessionRecording', {
                 sessionVideoId: this.get('session').get('videoId')
             });
-            return sessionRecorder.stop(this.get('sessionMaxUploadSeconds') * 1000);
+            return sessionRecorder.stop(this.get('sessionMaxUploadSeconds') * 1000)
+                .then(() => {
+                    this.set('_stopping', false);
+                    this.send('setTimeEvent', 'uploadComplete', {
+                        sessionVideoId: this.get('session').get('videoId')
+                    });
+                })
+                .catch((e) => {
+                    this.set('_stopping', false);
+                    // This block catches upload timeouts and any other errors related to stopping the recorder or uploading the data.
+                    // This session recorder stop promise rejection will not cause the experiment to stop with an error,
+                    // because the code waiting on this promise is in a "finally" block (rather than "then").
+                    if (e == 'uploadTimedout') {
+                        this.send('setTimeEvent', 'sessionRecordingUploadTimedout', {
+                            sessionVideoId: this.get('session').get('videoId')
+                        });
+                    } else {
+                        this.send('setTimeEvent', 'errorStoppingSessionRecording', {
+                            error: e,
+                            sessionVideoId: this.get('session').get('videoId')
+                        });
+                        throw new Error(`Error stopping session recorder and uploading: ${e}`);
+                    }
+                });
         } else {
-            return Ember.RSVP.reject();
+            // reject the promise because the recorder is in one of the following states:
+            // - doesn't exist, or is not recording, or has been destroyed
+            // - exists and is recording, but is already in the process of stopping and uploading
+            return Ember.RSVP.reject(new Error(`Unable to stop recorder for ${this.get('session').get('videoId')}. Maybe it does not exist, is not recording, has been destroyed, or is already stopping.`));
         }
     },
 

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -52,8 +52,7 @@ let {
  * See 'methods' for the functions you can use on a frame that extends VideoRecord.
  *
  * Events recorded in a frame that extends VideoRecord will automatically have additional
- * fields videoId (video filename), pipeId (temporary filename initially assigned by
- * the recording service), and streamTime (when in the video they happened, in s).
+ * fields videoId (video filename) and streamTime (when in the video they happened, in s).
  *
  * Setting up the camera is handled in didInsertElement, and making sure recording is
  * stopped is handled in willDestroyElement (Ember hooks that fire during the component

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -372,7 +372,7 @@ export default Ember.Mixin.create({
                 })
                 .catch((err) => {
                     this.send('setTimeEvent', 'errorStartingRecording', {
-                        error: err
+                        error: err.message
                     });
                     console.error(`Error starting recording for file: ${_this.get('videoName')}\n${err.name}: ${err.message}`);
                     throw new Error(`Error starting recording for file: ${_this.get('videoName')}\n${err.name}: ${err.message}`)
@@ -421,7 +421,7 @@ export default Ember.Mixin.create({
                         this.send('setTimeEvent', 'recordingUploadTimedout');
                     } else {
                         this.send('setTimeEvent', 'errorStoppingRecorder', {
-                            error: e
+                            error: e.message
                         });
                         throw new Error(`Error stopping recorder and uploading: ${e}`);
                     }

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -295,11 +295,14 @@ export default Ember.Mixin.create({
      * @return {Object} Event data object
      */
     makeTimeEvent(eventName, extra) {
-        // All frames using this mixin will add streamTime to every server event
+        // All frames using this mixin will add streamTime and video ID to every event
         let base = this._super(eventName, extra);
-        Ember.assign(base, {
-            streamTime: this.get('recorder') ? this.get('recorder').getTime() : null
-        });
+        if (this.get('recorder') && this.get('videoId')) {
+            Ember.assign(base, {
+                streamTime: this.get('recorder').getTime(),
+                videoId: this.get('videoId')
+            });
+        }
         return base;
     },
 
@@ -342,9 +345,7 @@ export default Ember.Mixin.create({
             }
         });
         this.set('recorder', recorder);
-        this.send('setTimeEvent', 'setupVideoRecorder', {
-            videoId: videoId
-        });
+        this.send('setTimeEvent', 'setupVideoRecorder');
         
         return installPromise;
     },
@@ -359,9 +360,7 @@ export default Ember.Mixin.create({
         var _this = this;
         if (recorder) {
             return recorder.record().then(() => {
-                this.send('setTimeEvent', 'startRecording', {
-                    pipeId: recorder.get('videoName') // TO DO: change 'pipeId' to something else 
-                });
+                this.send('setTimeEvent', 'startRecording');
                 if (this.get('videoList') == null) {
                     this.set('videoList', [this.get('videoId')]);
                 } else {

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -416,7 +416,7 @@ export default Ember.Mixin.create({
                     // This block catches upload timeouts and any other errors related to stopping the recorder or uploading the data.
                     // This session recorder stop promise rejection will not cause the experiment to stop with an error,
                     // because the code waiting on this promise is in a "finally" block (rather than "then").
-                    if (e == 'uploadTimedout') {
+                    if (e.message == 'uploadTimedout') {
                         this.send('setTimeEvent', 'recordingUploadTimedout');
                     } else {
                         this.send('setTimeEvent', 'errorStoppingRecorder', {

--- a/app/mixins/video-record.js
+++ b/app/mixins/video-record.js
@@ -375,6 +375,7 @@ export default Ember.Mixin.create({
                         error: err
                     });
                     console.error(`Error starting recording for file: ${_this.get('videoName')}\n${err.name}: ${err.message}`);
+                    throw new Error(`Error starting recording for file: ${_this.get('videoName')}\n${err.name}: ${err.message}`)
                 });
         } else {
             return Ember.RSVP.reject(new Error('Must call setupRecorder before startRecorder'));

--- a/app/mixins/video-record.rst
+++ b/app/mixins/video-record.rst
@@ -130,8 +130,8 @@ If your frame uses the video-record mixin, you may see the following in addition
 
 :startRecording: When video recorder has actually started recording
 
-    :pipeId: [String] Original filename assigned by the Pipe client. May be used for troubleshooting.
-
 :stoppingCapture: Just before stopping webcam video capture
 
 :destroyingRecorder: When video recorder is about to be destroyed before next frame
+
+All video-related events should include the ``videoId`` (video filename).

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -425,7 +425,7 @@ const VideoRecorder = Ember.Object.extend({
      */
     getTime() {
         let recorder = this.get('recorder');
-        if (recorder && this._started && this._startTime) {
+        if (recorder && this._started && this._startTime && this.get('_recording')) {
             let ts = Math.round(performance.now() - this._startTime);
             return ts; 
         }

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -466,7 +466,7 @@ const VideoRecorder = Ember.Object.extend({
                 })
                 .then(() => {
                     // After upload completed successfully
-                    _this._onUploadDone(this.get('recorderId'), this.get('s3').key);
+                    _this.onUploadDone(this.get('recorderId'), this.get('s3').key);
                 })
                 .catch((e) => {
                     throw new Error(`${e}`);

--- a/app/services/video-recorder.js
+++ b/app/services/video-recorder.js
@@ -547,7 +547,7 @@ const VideoRecorder = Ember.Object.extend({
 
     on(hookName, func) {
         if (this.get('hooks').indexOf(hookName) === -1) {
-            throw `Invalid event ${hookName}`;
+            throw new Error(`Invalid event ${hookName}`);
         }
         this.set(hookName, func);
     },


### PR DESCRIPTION
Part of #395 (but should not automatically close that issue).

This PR adds logging about upload problems to the experiment data, so that researchers have some indication of why a video isn't listed in a given response, and improves our Sentry logging for uploading problems.

## Explanation of changes

- Removed the mix of `async`/`await` and `then`/`catch` promise chains for consistency and to improve error catching. Previously, some promises were `awaited` but not part of the returned promise chain, so any problems related to those promises were not being caught. Now, all of the necessary steps for starting and stopping/uploading will be in the same promise chain that is returned from the functions, which makes it easer to catch/log errors that occur during the whole chain of events.
- Added catch blocks to these promise chains, so that we can catch/log all potential problems. The catch blocks in `video-recorder` should always throw an error so that the error propagates to the video/session recording mixins, where it can be logged in the data. In many cases the video/session recording mixins will also throw an error, but sometimes not (e.g. if the stop recording promise was rejected because of an upload timeout, then we just want to log that event and continue as normal).
- Improve consistency around rejecting promises (always include a reason) and throwing errors (throw an Error object, not just a string). This will provide more detailed event logs in the data and in Sentry.
- When a participant leaves the study early, try to complete in-progress trial recording (not just session recording).

New events logged in the data:
- errorStartingRecording
- errorStoppingRecorder / errorStoppingSessionRecording
- recordingUploadTimedout / sessionRecordingUploadTimedout
- uploadComplete

## Examples

Here's what things look like in the experiment data. If this PR is approved then I will add all of this info to the researcher documentation.

### Upload successful

If the "uploadComplete" event is logged for a particular file, then that file should be available for the researcher to download. If the researcher does not see the video file in the Responses pages, then they should contact us so that we can investigate.

```javascript
{
    "videoId": "consent-videoStream_5fc855b5-6d92-4f53-9404-ad251c30bb8f_0-video-consent_a72079fb-99cf-463f-9106-2eea240d0c8c_1721944527372_591",
    "eventType": "exp-lookit-video-consent:uploadComplete",
    "timestamp": "2024-07-25T21:55:39.328Z",
    "streamTime": null
}
```

### Upload timed out

If the "recordingUploadTimedout" event is logged for a particular file, then that file might or might not be available for the researcher to download. If the researcher does not see the video file in the Responses pages after 24 hours, then there was probably a problem with the participant's internet connection during the study session.

```javascript
{
    "videoId": "consent-videoStream_5fc855b5-6d92-4f53-9404-ad251c30bb8f_0-video-consent_fabe522e-ff4e-42b3-8cc9-1d8c4d8934be_1721945400049_935",
    "eventType": "exp-lookit-video-consent:recordingUploadTimedout",
    "timestamp": "2024-07-25T22:10:12.568Z",
    "streamTime": null
},
```

### Error stopping/uploading

If the "errorStoppingRecorder" event is logged for a particular file, then that file failed to save and will not be available for the researcher to download. This error could be due to problems with our S3 settings/credentials, existing file name in S3 for this upload, in-progress upload that was completed/aborted too soon, etc. This type of error is unlikely to occur but I've included it in the researcher data to allow us to easily identify or rule out missing videos that might be caused by these problems.

```javascript
{
    "error": "Error: Error: Error completing upload: Error: Upload part failed after 3 attempts.\nError: NoSuchUpload: The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
    "videoId": "consent-videoStream_5fc855b5-6d92-4f53-9404-ad251c30bb8f_0-video-consent_ff75dbda-0963-404a-a39b-aec576e8b82d_1722034788775_747",
    "eventType": "exp-lookit-video-consent:errorStoppingRecorder",
    "timestamp": "2024-07-26T22:59:57.034Z",
    "streamTime": null
},
```