### PR TITLE
Replace links to old docs site with current links

### DIFF
--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -195,7 +195,7 @@ export default Ember.Component.extend(FullScreen, {
             var availableFrames = Ember.getOwner(this).lookup(`container-debug-adapter:main`).catalogEntriesByType('component')
                 .filter(componentName => componentName.includes('component') && componentName.includes('exp-') && !['components/exp-blank', 'components/exp-frame-base', 'components/exp-text-block', 'components/exp-player'].includes(componentName))
                 .map(componentName => componentName.replace('components/', ''));
-            console.error(`Unknown frame kind '${componentName}' specified. Check that 'kind' is specified for all frames and that it is always one of the following available frame kinds:\n\t${availableFrames.join('\n\t')}\nFrames are described in more detail https://lookit.github.io/ember-lookit-frameplayer/modules/frames.html. Frame kinds are all lowercase, like 'exp-lookit-exit-survey'. If you are trying to use a newer frame, you may need to update the frameplayer code for your study; see https://lookit.readthedocs.io/en/develop/researchers-update-code.html.`);
+            console.error(`Unknown frame kind '${componentName}' specified. Check that 'kind' is specified for all frames and that it is always one of the following available frame kinds:\n\t${availableFrames.join('\n\t')}\nFrames are described in more detail https://lookit.readthedocs.io/projects/frameplayer/en/latest/utils/protocol.html#study-protocol-structure. Frame kinds are all lowercase, like 'exp-lookit-exit-survey'. If you are trying to use a newer frame, you may need to update the frameplayer code for your study; see https://lookit.readthedocs.io/en/master/researchers-update-code.html.`);
         }
         return componentName;
     }),

--- a/app/randomizers/overview.rst
+++ b/app/randomizers/overview.rst
@@ -210,7 +210,7 @@ You have a variety of options for how to accomplish random condition assignment:
         ]
     }
 
-3. You can use the ``#RAND`` syntax and `frame parameters <https://lookit.github.io/lookit-frameplayer-docs/classes/Exp-frame-base.html#property_parameters>`_ to substitute in one of the two options for each condition:
+3. You can use the ``#RAND`` syntax and :ref:`frame parameters <frame parameters>` to substitute in one of the two options for each condition:
 
 ::
 

--- a/app/randomizers/random-parameter-set.rst
+++ b/app/randomizers/random-parameter-set.rst
@@ -59,7 +59,7 @@ use the ``random-parameter-set`` randomizer:
 
 .. admonition:: Advanced options for choosing the parameterSet
 
-   You can `determine the weights based on the child's age <https://lookit.github.io/lookit-frameplayer-docs/classes/Random-parameter-set.html#property_parameterSetWeights>`_, to maintain balanced conditions.) You can also `keep kids in the same condition across all sessions they complete, or rotate them through conditions in order  <https://lookit.github.io/lookit-frameplayer-docs/classes/Random-parameter-set.html#property_conditionForAdditionalSessions>`_.
+   You can :ref:`determine the weights based on the child's age<parameter-set-weights>` to maintain balanced conditions. You can also :ref:`keep kids in the same condition across all sessions they complete, or rotate them through conditions in order<condition-for-additional-sessions>`.
 
 
 Examples
@@ -226,7 +226,7 @@ pairs):
 Next, one of the two objects in ``parameterSets`` is selected randomly.
 (By default, parameter sets are weighted equally, but
 ``parameterSetWeights`` can be provided as an optional key in the
-``random-parameter-set`` frame. If provided, ``parameterSetWeights``
+``random-parameter-set`` frame.) If provided, ``parameterSetWeights``
 should be an array of relative weights for the parameter sets,
 corresponding to the order they are listed. For instance, if we wanted
 75% of participants to think about how tasty broccoli is, we could set
@@ -474,8 +474,9 @@ parameterSets [Array]
 
     A single element of `parameterSets` will be applied to a given session.
 
-conditionForAdditionalSessions [String | ``'random'``]
+.. _condition-for-additional-sessions:
 
+conditionForAdditionalSessions [String | ``'random'``]
     [Optional] How to select a parameterSet for a participant who has previously
     participated in this study. Must be one of ``'random'`` (default), ``'persist'``, or
     ``'rotate'``. Meanings:
@@ -513,8 +514,9 @@ conditionForAdditionalSessions [String | ``'random'``]
     but then you changed ``parameterSets`` to have only 3 elements) and ``conditionForAdditionalSessions`` is
     ``"persist"``, then the participant is assigned to the last element of ``parameterSets``.
 
-parameterSetWeights [Array]
+.. _parameter-set-weights:
 
+parameterSetWeights [Array]
     [Optional] Array of weights for parameter sets; elements correspond to
     elements of parameterSets. The probability of selecting an element
     ``parameterSets[i]`` is ``parameterSetWeights[i]/sum(parameterSetWeights)``.


### PR DESCRIPTION
Fixes #411 

This PR updates some links to the old docs site (lookit.github.io) with current links. I've kept the old links on the "deprecated" page that specifically say they reference the old site.

I've tested all of the new links and they are working.